### PR TITLE
Fix typo in Bing search API key line

### DIFF
--- a/examples/costorm_examples/run_costorm_gpt.py
+++ b/examples/costorm_examples/run_costorm_gpt.py
@@ -5,7 +5,7 @@ You need to set up the following environment variables to run this script:
     - OPENAI_API_TYPE: OpenAI API type (e.g., 'openai' or 'azure')
     - AZURE_API_BASE: Azure API base URL if using Azure API
     - AZURE_API_VERSION: Azure API version if using Azure API
-    - BING_SEARCH_API_KEY: Biang search API key; BING_SEARCH_API_KEY: Bing Search API key, SERPER_API_KEY: Serper API key, BRAVE_API_KEY: Brave API key, or TAVILY_API_KEY: Tavily API key
+    - BING_SEARCH_API_KEY: Bing search API key; BING_SEARCH_API_KEY: Bing Search API key, SERPER_API_KEY: Serper API key, BRAVE_API_KEY: Brave API key, or TAVILY_API_KEY: Tavily API key
 
 Output will be structured as below
 args.output_dir/


### PR DESCRIPTION
## Summary
- correct spelling of "Bing search API key" in Co-STORM example

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_686f27719c308326a544cbff7dffc202