### PR TITLE
Fix NameError in Groq example

### DIFF
--- a/examples/storm_examples/run_storm_wiki_groq.py
+++ b/examples/storm_examples/run_storm_wiki_groq.py
@@ -19,7 +19,10 @@ args.output_dir/
 
 import os
 import re
+import logging
 from argparse import ArgumentParser
+
+logger = logging.getLogger(__name__)
 
 from knowledge_storm import (
     STORMWikiRunnerArguments,


### PR DESCRIPTION
## Summary
- import logging and create a logger in `run_storm_wiki_groq.py`

## Testing
- `pre-commit run --files examples/storm_examples/run_storm_wiki_groq.py`
- `python -m py_compile examples/storm_examples/run_storm_wiki_groq.py`

------
https://chatgpt.com/codex/tasks/task_e_686f27702a108326a5ba54df35dcea58