### PR TITLE
Fix unused variable and import

### DIFF
--- a/examples/costorm_examples/run_costorm_gpt.py
+++ b/examples/costorm_examples/run_costorm_gpt.py
@@ -64,7 +64,6 @@ def main(args):
     )
     # If you are using Azure service, make sure the model name matches your own deployed model name.
     # The default name here is only used for demonstration and may not match your case.
-    gpt_4o_mini_model_name = "gpt-4o-mini"
     gpt_4o_model_name = "gpt-4o"
     if os.getenv("OPENAI_API_TYPE") == "azure":
         openai_kwargs["api_base"] = os.getenv("AZURE_API_BASE")

--- a/examples/storm_examples/run_storm_wiki_ollama.py
+++ b/examples/storm_examples/run_storm_wiki_ollama.py
@@ -17,7 +17,6 @@ args.output_dir/
 """
 
 import os
-import sys
 from argparse import ArgumentParser
 
 from dspy import Example


### PR DESCRIPTION
## Summary
- remove unused `gpt_4o_mini_model_name`
- delete `sys` import from `run_storm_wiki_ollama.py`

## Testing
- `pytest -q`
- `ruff check examples/costorm_examples/run_costorm_gpt.py examples/storm_examples/run_storm_wiki_ollama.py`


------
https://chatgpt.com/codex/tasks/task_e_686f29f44bd483269ad4c2691431c372