### PR TITLE
Add Storm wrapper API

### DIFF
--- a/tino_storm/__init__.py
+++ b/tino_storm/__init__.py
@@ -1,0 +1,4 @@
+from .config import StormConfig
+from .storm import Storm, run_pipeline
+
+__all__ = ["StormConfig", "Storm", "run_pipeline"]

--- a/tino_storm/config.py
+++ b/tino_storm/config.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import Any
+
+from knowledge_storm.storm_wiki.engine import (
+    STORMWikiRunnerArguments,
+    STORMWikiLMConfigs,
+)
+
+
+@dataclass
+class StormConfig:
+    """Aggregate configuration for running a STORM pipeline."""
+
+    args: STORMWikiRunnerArguments
+    lm_configs: STORMWikiLMConfigs
+    rm: Any

--- a/tino_storm/storm.py
+++ b/tino_storm/storm.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from knowledge_storm import STORMWikiRunner, BaseCallbackHandler
+
+from .config import StormConfig
+
+
+class Storm:
+    """Convenient wrapper around :class:`STORMWikiRunner`."""
+
+    def __init__(self, config: StormConfig):
+        self.config = config
+        self.runner = STORMWikiRunner(config.args, config.lm_configs, config.rm)
+
+    def build_outline(
+        self,
+        topic: str,
+        ground_truth_url: str = "",
+        callback_handler: Optional[BaseCallbackHandler] = None,
+    ):
+        return self.runner.build_outline(
+            topic=topic,
+            ground_truth_url=ground_truth_url,
+            callback_handler=callback_handler or BaseCallbackHandler(),
+        )
+
+    def generate_article(
+        self,
+        callback_handler: Optional[BaseCallbackHandler] = None,
+    ):
+        return self.runner.generate_article(
+            callback_handler=callback_handler or BaseCallbackHandler()
+        )
+
+    def polish_article(self, remove_duplicate: bool = False):
+        return self.runner.polish_article(remove_duplicate=remove_duplicate)
+
+    def run_pipeline(
+        self,
+        topic: str,
+        ground_truth_url: str = "",
+        remove_duplicate: bool = False,
+        callback_handler: Optional[BaseCallbackHandler] = None,
+    ):
+        self.build_outline(topic, ground_truth_url, callback_handler=callback_handler)
+        self.generate_article(callback_handler=callback_handler)
+        article = self.polish_article(remove_duplicate=remove_duplicate)
+        self.runner.post_run()
+        return article
+
+
+def run_pipeline(
+    config: StormConfig,
+    topic: str,
+    ground_truth_url: str = "",
+    remove_duplicate: bool = False,
+):
+    """Run the full STORM pipeline with one function call."""
+    storm = Storm(config)
+    return storm.run_pipeline(topic, ground_truth_url, remove_duplicate)


### PR DESCRIPTION
## Summary
- add a new `tino_storm` package exposing a user-friendly `Storm` class
- define `StormConfig` dataclass for wrapping runner arguments, LM config and retriever
- refactor `STORMWikiRunner.run` into smaller methods (`build_outline`, `generate_article`, `polish_article`)

## Testing
- `pre-commit run --files tino_storm/config.py tino_storm/storm.py tino_storm/__init__.py knowledge_storm/storm_wiki/engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2b30e0248326a43a3326f46570c1