### PR TITLE
Add CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ python examples/storm_examples/run_storm_wiki_gpt.py \
 ```
 
 **To run STORM using your favorite language models or grounding on your own corpus:** Check out [examples/storm_examples/README.md](examples/storm_examples/README.md).
+You can also run STORM from the command line after installation:
+```bash
+tino-storm --output-dir $OUTPUT_DIR --retriever bing
+```
 
 ### Co-STORM examples
 

--- a/examples/storm_examples/README.md
+++ b/examples/storm_examples/README.md
@@ -1,6 +1,11 @@
 # Examples
 
 We host a number of example scripts for various customization of STORM (e.g., use your favorite language models, use your own corpus, etc.). These examples can be starting points for your own customizations and you are welcome to contribute your own examples by submitting a pull request to this directory.
+You can also run the STORM pipeline from the command line once the package is installed:
+```bash
+tino-storm --output-dir results --retriever bing
+```
+
 
 ## Run STORM with your own language model
 [run_storm_wiki_gpt.py](run_storm_wiki_gpt.py) provides an example of running STORM with GPT models, and [run_storm_wiki_claude.py](run_storm_wiki_claude.py) provides an example of running STORM with Claude models. Besides using close-source models, you can also run STORM with models with open weights.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "knowledge-storm"
+version = "1.1.0"
+requires-python = ">=3.10"
+readme = "README.md"
+
+[project.scripts]
+tino-storm = "tino_storm.cli:main"

--- a/tino_storm/__init__.py
+++ b/tino_storm/__init__.py
@@ -1,2 +1,45 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from knowledge_storm import BaseCallbackHandler
+
+from .config import StormConfig
+from .storm import Storm, run_pipeline
 
 
+def build_outline(
+    config: StormConfig,
+    topic: str,
+    ground_truth_url: str = "",
+    callback_handler: Optional[BaseCallbackHandler] = None,
+):
+    """Generate an outline for ``topic`` using ``config``."""
+    return Storm(config).build_outline(
+        topic=topic,
+        ground_truth_url=ground_truth_url,
+        callback_handler=callback_handler,
+    )
+
+
+def generate_article(
+    config: StormConfig,
+    callback_handler: Optional[BaseCallbackHandler] = None,
+):
+    """Generate an article using the previously built outline."""
+    return Storm(config).generate_article(callback_handler=callback_handler)
+
+
+def polish_article(config: StormConfig, remove_duplicate: bool = False):
+    """Polish the generated article."""
+    return Storm(config).polish_article(remove_duplicate=remove_duplicate)
+
+
+__all__ = [
+    "Storm",
+    "run_pipeline",
+    "build_outline",
+    "generate_article",
+    "polish_article",
+    "StormConfig",
+]

--- a/tino_storm/cli.py
+++ b/tino_storm/cli.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import argparse
+import os
+
+from knowledge_storm import (
+    STORMWikiRunnerArguments,
+    STORMWikiLMConfigs,
+)
+from knowledge_storm.lm import OpenAIModel, AzureOpenAIModel
+from knowledge_storm.utils import load_api_key
+
+from .config import StormConfig
+from .providers import get_retriever
+from .storm import Storm
+
+
+def make_config(args: argparse.Namespace) -> StormConfig:
+    """Create a :class:`StormConfig` from command line ``args``."""
+    load_api_key(toml_file_path="secrets.toml")
+
+    openai_type = os.getenv("OPENAI_API_TYPE", "openai")
+    openai_kwargs = {
+        "api_key": os.getenv("OPENAI_API_KEY"),
+        "temperature": 1.0,
+        "top_p": 0.9,
+    }
+    if openai_type == "azure":
+        openai_kwargs["api_base"] = os.getenv("AZURE_API_BASE")
+        openai_kwargs["api_version"] = os.getenv("AZURE_API_VERSION")
+
+    model_cls = OpenAIModel if openai_type == "openai" else AzureOpenAIModel
+    gpt_35 = "gpt-3.5-turbo" if openai_type == "openai" else "gpt-35-turbo"
+    gpt_4 = "gpt-4o"
+
+    conv_simulator_lm = model_cls(model=gpt_35, max_tokens=500, **openai_kwargs)
+    question_asker_lm = model_cls(model=gpt_35, max_tokens=500, **openai_kwargs)
+    outline_gen_lm = model_cls(model=gpt_4, max_tokens=400, **openai_kwargs)
+    article_gen_lm = model_cls(model=gpt_4, max_tokens=700, **openai_kwargs)
+    article_polish_lm = model_cls(model=gpt_4, max_tokens=4000, **openai_kwargs)
+
+    lm_configs = STORMWikiLMConfigs()
+    lm_configs.set_conv_simulator_lm(conv_simulator_lm)
+    lm_configs.set_question_asker_lm(question_asker_lm)
+    lm_configs.set_outline_gen_lm(outline_gen_lm)
+    lm_configs.set_article_gen_lm(article_gen_lm)
+    lm_configs.set_article_polish_lm(article_polish_lm)
+
+    engine_args = STORMWikiRunnerArguments(
+        output_dir=args.output_dir,
+        max_conv_turn=args.max_conv_turn,
+        max_perspective=args.max_perspective,
+        search_top_k=args.search_top_k,
+        max_thread_num=args.max_thread_num,
+        retrieve_top_k=args.retrieve_top_k,
+    )
+
+    rm_cls = get_retriever(args.retriever)
+    rm_kwargs = {"k": engine_args.search_top_k}
+    if args.retriever == "bing":
+        rm_kwargs["bing_search_api_key"] = os.getenv("BING_SEARCH_API_KEY")
+    elif args.retriever == "you":
+        rm_kwargs["ydc_api_key"] = os.getenv("YDC_API_KEY")
+    elif args.retriever == "brave":
+        rm_kwargs["brave_search_api_key"] = os.getenv("BRAVE_API_KEY")
+    elif args.retriever == "duckduckgo":
+        rm_kwargs.update({"safe_search": "On", "region": "us-en"})
+    elif args.retriever == "serper":
+        rm_kwargs["serper_search_api_key"] = os.getenv("SERPER_API_KEY")
+        rm_kwargs["query_params"] = {"autocorrect": True, "num": 10, "page": 1}
+    elif args.retriever == "tavily":
+        rm_kwargs["tavily_search_api_key"] = os.getenv("TAVILY_API_KEY")
+        rm_kwargs["include_raw_content"] = True
+    elif args.retriever == "searxng":
+        rm_kwargs["searxng_api_key"] = os.getenv("SEARXNG_API_KEY")
+    elif args.retriever == "azure_ai_search":
+        rm_kwargs["azure_ai_search_api_key"] = os.getenv("AZURE_AI_SEARCH_API_KEY")
+    rm = rm_cls(**rm_kwargs)
+
+    return StormConfig(engine_args, lm_configs, rm)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run the STORM pipeline")
+    parser.add_argument(
+        "--output-dir", type=str, default="./results/cli", help="Directory for outputs"
+    )
+    parser.add_argument(
+        "--max-thread-num", type=int, default=3, help="Maximum number of threads"
+    )
+    parser.add_argument(
+        "--retriever",
+        type=str,
+        required=True,
+        choices=[
+            "bing",
+            "you",
+            "brave",
+            "serper",
+            "duckduckgo",
+            "tavily",
+            "searxng",
+            "azure_ai_search",
+        ],
+        help="Search engine to use",
+    )
+    parser.add_argument("--max-conv-turn", type=int, default=3)
+    parser.add_argument("--max-perspective", type=int, default=3)
+    parser.add_argument("--search-top-k", type=int, default=3)
+    parser.add_argument("--retrieve-top-k", type=int, default=3)
+    parser.add_argument(
+        "--remove-duplicate", action="store_true", help="Remove duplicate text"
+    )
+    args = parser.parse_args(argv)
+
+    config = make_config(args)
+    storm = Storm(config)
+    topic = input("Topic: ")
+    article = storm.run_pipeline(topic, remove_duplicate=args.remove_duplicate)
+    print(article)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- expose common helpers in `tino_storm.__init__`
- provide `tino_storm.cli` for running the pipeline from the command line
- configure `tino-storm` entry point via `pyproject.toml`
- document CLI usage in README and examples

## Testing
- `pre-commit run --files README.md examples/storm_examples/README.md tino_storm/__init__.py tino_storm/cli.py pyproject.toml`

------
https://chatgpt.com/codex/tasks/task_e_68701db2bb18832684512db8aa6844e8