### PR TITLE
Add FastAPI API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,23 @@ python examples/costorm_examples/run_costorm_gpt.py \
     --retriever bing
 ```
 
+### Running the FastAPI server
+
+Install the optional FastAPI dependencies:
+
+```bash
+pip install .[fastapi]
+```
+
+Start the API server with:
+
+```bash
+uvicorn tino_storm.fastapi_app:app --reload
+```
+
+Then open `http://localhost:8000/docs` to explore the API.
+
+
 
 ## Customization of the Pipeline
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project.optional-dependencies]
+fastapi = ["fastapi", "uvicorn"]

--- a/tino_storm/fastapi_app.py
+++ b/tino_storm/fastapi_app.py
@@ -1,0 +1,60 @@
+"""FastAPI endpoints exposing STORM functionalities."""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from knowledge_storm import STORMWikiRunnerArguments, STORMWikiLMConfigs
+from knowledge_storm.rm import DuckDuckGoSearchRM
+
+from .config import StormConfig
+from .storm import Storm
+
+
+app = FastAPI(title="STORM API")
+
+
+class OutlineRequest(BaseModel):
+    topic: str
+    ground_truth_url: str | None = None
+
+
+def _create_storm() -> Storm:
+    """Create a :class:`Storm` instance with default configuration."""
+    args = STORMWikiRunnerArguments(
+        output_dir=os.getenv("STORM_OUTPUT_DIR", "storm_output")
+    )
+    lm_configs = STORMWikiLMConfigs()
+    openai_key = os.getenv("OPENAI_API_KEY")
+    if openai_key:
+        lm_configs.init_openai_model(
+            openai_api_key=openai_key,
+            azure_api_key=os.getenv("AZURE_API_KEY", ""),
+            openai_type=os.getenv("OPENAI_API_TYPE", "openai"),
+            api_base=os.getenv("AZURE_API_BASE"),
+            api_version=os.getenv("AZURE_API_VERSION"),
+        )
+    rm = DuckDuckGoSearchRM(k=args.search_top_k)
+    config = StormConfig(args=args, lm_configs=lm_configs, rm=rm)
+    return Storm(config)
+
+
+@app.post("/outline")
+async def generate_outline(req: OutlineRequest):
+    """Generate an outline for ``req.topic``."""
+    storm = _create_storm()
+    outline = storm.build_outline(
+        req.topic, ground_truth_url=req.ground_truth_url or ""
+    )
+    return {"outline": outline.to_string()}
+
+
+@app.post("/article")
+async def generate_article(req: OutlineRequest):
+    """Run the full pipeline to produce an article for ``req.topic``."""
+    storm = _create_storm()
+    article = storm.run_pipeline(req.topic, ground_truth_url=req.ground_truth_url or "")
+    return {"article": article.to_string()}


### PR DESCRIPTION
## Summary
- provide FastAPI app with outline & article endpoints
- document running the API
- declare optional fastapi extras in `pyproject.toml`

## Testing
- `pre-commit run --files tino_storm/fastapi_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68701db380b08326b9e7d21e3d3c3f85