### PR TITLE
Add smoke test and refine pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,22 @@ repos:
       - id: black
         name: Format Python code with black
         entry: black
-        args: ["knowledge_storm/"]
         language: python
+        files: "^(knowledge_storm|tino_storm|tests)/"
         pass_filenames: true
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.2
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+        files: "^(knowledge_storm|tino_storm|tests)/"
+
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: Run tests with pytest
+        entry: pytest
+        language: system
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,15 @@ Following the suggested format can lead to a faster review process.
 
 **Code Format:**
 
-We adopt [`black`](https://github.com/psf/black) for arranging and formatting Python code. To streamline the contribution process, we set up a [pre-commit hook](https://pre-commit.com/) to format the code under `knowledge_storm/` before committing. To install the pre-commit hook, run:
+We adopt [`black`](https://github.com/psf/black) for arranging and formatting Python code. To streamline the contribution process, we set up a [pre-commit hook](https://pre-commit.com/) to format the code under `knowledge_storm/` and `tino_storm/` before committing. To install the pre-commit hook, run:
 ```
 pip install pre-commit
 pre-commit install
 ```
 The hook will automatically format the code before each commit.
+
+The pre-commit configuration also runs [`ruff`](https://docs.astral.sh/ruff/) for
+linting and [`pytest`](https://pytest.org/) for tests. You may add
+[`mypy`](https://mypy-lang.org/) for optional type checking. These hooks operate on
+the `knowledge_storm/`, `tino_storm/`, and `tests/` directories. Running
+`pre-commit` locally will execute these checks automatically.

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,10 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def test_modules_available():
+    assert importlib.util.find_spec("knowledge_storm") is not None
+    assert importlib.util.find_spec("tino_storm") is not None


### PR DESCRIPTION
## Summary
- limit pre-commit hooks to knowledge_storm/ and tino_storm
- add pytest smoke test for module presence
- document new pre-commit workflow

## Testing
- `ruff check tests/test_imports.py`
- `black tests/test_imports.py --check`
- `pytest -q`
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md tests/test_imports.py`

------
https://chatgpt.com/codex/tasks/task_e_68701db7b3388326a362e31143629959