### PR TITLE
Fix import test for stubbed knowledge_storm

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,4 +1,4 @@
-import importlib.util
+import importlib
 import sys
 from pathlib import Path
 
@@ -6,5 +6,5 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
 def test_modules_available():
-    assert importlib.util.find_spec("knowledge_storm") is not None
-    assert importlib.util.find_spec("tino_storm") is not None
+    assert importlib.import_module("knowledge_storm") is not None
+    assert importlib.import_module("tino_storm") is not None


### PR DESCRIPTION
## Summary
- ensure import test loads modules via `import_module`

## Testing
- `ruff check tests/test_imports.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870403e35bc8326982053e288d2ea66