### PR TITLE
Add ingest watchdog and CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,24 @@ A short command line interface is available in `examples/cli_example.py`:
 python examples/cli_example.py "Quantum computing"
 ```
 
+
 `OPENAI_API_KEY` and `BING_SEARCH_API_KEY` must be set in the environment (or provided via `secrets.toml`).
+
+## Ingesting research data
+
+Use the command below to monitor a vault directory for new research files and automatically index them:
+
+```bash
+tino-storm ingest --vault my_vault
+```
+
+This watches `research/my_vault/` for PDFs, `urls.txt`, and JSON dumps. Detected files are ingested with
+LlamaIndex and stored in `~/.tino_storm/chroma/my_vault` using Chroma as the vector store. Install the optional
+dependencies with:
+
+```bash
+pip install watchdog llama-index chromadb
+```
 
 
 ## Optional FastAPI mode

--- a/tino_storm/cli.py
+++ b/tino_storm/cli.py
@@ -81,15 +81,32 @@ def make_config(args: argparse.Namespace) -> StormConfig:
     return StormConfig(engine_args, lm_configs, rm)
 
 
+def _run_storm(args: argparse.Namespace) -> None:
+    config = make_config(args)
+    storm = Storm(config)
+    topic = input("Topic: ")
+    article = storm.run_pipeline(topic, remove_duplicate=args.remove_duplicate)
+    print(article)
+
+
+def _run_ingest(args: argparse.Namespace) -> None:
+    from .ingest import watch_vault
+
+    watch_vault(args.vault)
+
+
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Run the STORM pipeline")
-    parser.add_argument(
+    parser = argparse.ArgumentParser(description="tino-storm command line")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = sub.add_parser("run", help="Run the STORM pipeline")
+    run_parser.add_argument(
         "--output-dir", type=str, default="./results/cli", help="Directory for outputs"
     )
-    parser.add_argument(
+    run_parser.add_argument(
         "--max-thread-num", type=int, default=3, help="Maximum number of threads"
     )
-    parser.add_argument(
+    run_parser.add_argument(
         "--retriever",
         type=str,
         required=True,
@@ -105,20 +122,21 @@ def main(argv: list[str] | None = None) -> None:
         ],
         help="Search engine to use",
     )
-    parser.add_argument("--max-conv-turn", type=int, default=3)
-    parser.add_argument("--max-perspective", type=int, default=3)
-    parser.add_argument("--search-top-k", type=int, default=3)
-    parser.add_argument("--retrieve-top-k", type=int, default=3)
-    parser.add_argument(
+    run_parser.add_argument("--max-conv-turn", type=int, default=3)
+    run_parser.add_argument("--max-perspective", type=int, default=3)
+    run_parser.add_argument("--search-top-k", type=int, default=3)
+    run_parser.add_argument("--retrieve-top-k", type=int, default=3)
+    run_parser.add_argument(
         "--remove-duplicate", action="store_true", help="Remove duplicate text"
     )
-    args = parser.parse_args(argv)
+    run_parser.set_defaults(func=_run_storm)
 
-    config = make_config(args)
-    storm = Storm(config)
-    topic = input("Topic: ")
-    article = storm.run_pipeline(topic, remove_duplicate=args.remove_duplicate)
-    print(article)
+    ingest_parser = sub.add_parser("ingest", help="Ingest research files")
+    ingest_parser.add_argument("--vault", required=True, help="Name of the research vault")
+    ingest_parser.set_defaults(func=_run_ingest)
+
+    args = parser.parse_args(argv)
+    args.func(args)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/tino_storm/ingest/__init__.py
+++ b/tino_storm/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for ingesting research data."""
+
+from .watchdog import watch_vault
+
+__all__ = ["watch_vault"]

--- a/tino_storm/ingest/watchdog.py
+++ b/tino_storm/ingest/watchdog.py
@@ -1,0 +1,62 @@
+"""File system watcher for ingesting research files."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from watchdog.events import FileSystemEventHandler, FileSystemEvent
+from watchdog.observers import Observer
+
+from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
+from llama_index.vector_stores.chroma import ChromaVectorStore
+
+
+class IngestHandler(FileSystemEventHandler):
+    """Handle new files in a research vault."""
+
+    def __init__(self, vault: str):
+        self.vault = vault
+        self.vault_dir = Path("research") / vault
+        self.storage_dir = Path("~/.tino_storm/chroma").expanduser() / vault
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+        vector_store = ChromaVectorStore(persist_path=str(self.storage_dir))
+        self.index = VectorStoreIndex.from_vector_store(vector_store)
+
+    def _should_ingest(self, path: Path) -> bool:
+        if path.name == "urls.txt":
+            return True
+        if path.suffix.lower() in {".pdf", ".json", ".txt"}:
+            return True
+        return False
+
+    def ingest_file(self, path: Path) -> None:
+        if not self._should_ingest(path):
+            return
+        docs = SimpleDirectoryReader(input_files=[str(path)]).load_data()
+        if not docs:
+            return
+        for node in docs:
+            self.index.insert_nodes([node])
+        self.index.vector_store.persist()
+
+    def on_created(self, event: FileSystemEvent) -> None:  # pragma: no cover - integration
+        if event.is_directory:
+            return
+        self.ingest_file(Path(event.src_path))
+
+
+def watch_vault(vault: str) -> None:
+    """Watch the given research ``vault`` directory for new files and ingest them."""
+    watch_path = Path("research") / vault
+    watch_path.mkdir(parents=True, exist_ok=True)
+    handler = IngestHandler(vault)
+    observer = Observer()
+    observer.schedule(handler, str(watch_path), recursive=False)
+    observer.start()
+    try:
+        while True:  # pragma: no cover - long running loop
+            time.sleep(1)
+    except KeyboardInterrupt:  # pragma: no cover - manual stop
+        observer.stop()
+    observer.join()


### PR DESCRIPTION
## Summary
- monitor research vaults for new PDFs and dumps
- ingest files into Chroma collections via new watchdog module
- expose `tino-storm ingest --vault <name>` CLI command
- document ingest command and dependencies in README

## Testing
- `ruff check tino_storm tests`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68704656925083268ab439902ccbe8fe