### PR TITLE
Add DSPy ResearchSkill

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ article = runner.run(topic="Deep learning", do_research=True, do_generate_outlin
 print(article)
 ```
 
+## DSPy ResearchSkill
+
+The package exposes a small `ResearchSkill` wrapper to compose the outline,
+draft and polish modules. This can be used directly with DSPy tuning utilities.
+
+```python
+from tino_storm.dsp import ResearchSkill
+
+skill = ResearchSkill(
+    outline_lm=lm_configs.outline_gen_lm,
+    draft_lm=lm_configs.article_gen_lm,
+    polish_lm=lm_configs.article_polish_lm,
+)
+# `table` should be a StormInformationTable instance from the curation stage
+article = skill("Deep learning", table)
+```
+
 ## CLI usage
 
 A short command line interface is available in `examples/cli_example.py`:

--- a/research/another_vault/eval.jsonl
+++ b/research/another_vault/eval.jsonl
@@ -1,0 +1,1 @@
+{"topic": "Climate change", "expected": "CC article"}

--- a/research/example_vault/eval.jsonl
+++ b/research/example_vault/eval.jsonl
@@ -1,0 +1,2 @@
+{"topic": "Quantum computing", "expected": "QC article"}
+{"topic": "Machine learning", "expected": "ML article"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,10 @@
 # knowledge_storm modules are stubbed in tests/conftest.py
 
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from tino_storm.config import StormConfig
 from knowledge_storm.storm_wiki.engine import (
     STORMWikiRunnerArguments,

--- a/tests/test_research_skill.py
+++ b/tests/test_research_skill.py
@@ -1,0 +1,50 @@
+import dspy
+from tino_storm.dsp import ResearchSkill
+
+
+class StubLM(dspy.LM):
+    """Simple LM that always returns a preset response."""
+
+    def __init__(self, response: str):
+        super().__init__(model="stub")
+        self.response = response
+
+    def basic_request(self, prompt, **kwargs):
+        return self.response
+
+
+class StubOutlineModule:
+    def __init__(self, resp="outline"):
+        self.resp = resp
+
+    def generate_outline(self, topic, information_table, callback_handler=None):
+        return self.resp
+
+
+class StubDraftModule:
+    def __init__(self, resp="draft"):
+        self.resp = resp
+
+    def generate_article(
+        self, topic, information_table, article_with_outline, callback_handler=None
+    ):
+        return self.resp
+
+
+class StubPolishModule:
+    def __init__(self, resp="polished"):
+        self.resp = resp
+
+    def polish_article(self, topic, draft_article, remove_duplicate=False):
+        return self.resp
+
+
+def test_research_skill_runs_with_stubs():
+    skill = ResearchSkill(
+        outline_module=StubOutlineModule("o"),
+        draft_module=StubDraftModule("d"),
+        polish_module=StubPolishModule("p"),
+    )
+
+    result = skill("topic", None)
+    assert result == "p"

--- a/tino_storm/dsp/__init__.py
+++ b/tino_storm/dsp/__init__.py
@@ -1,0 +1,3 @@
+from .skill import ResearchSkill
+
+__all__ = ["ResearchSkill"]

--- a/tino_storm/dsp/skill.py
+++ b/tino_storm/dsp/skill.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Optional
+
+
+class ResearchSkill:
+    """High level skill that runs outline, draft and polish modules."""
+
+    def __init__(
+        self,
+        outline_lm=None,
+        draft_lm=None,
+        polish_lm=None,
+        *,
+        outline_module=None,
+        draft_module=None,
+        polish_module=None,
+    ):
+        if outline_module is None:
+            from knowledge_storm.storm_wiki.modules.outline_generation import (
+                StormOutlineGenerationModule,
+            )
+
+            outline_module = StormOutlineGenerationModule(outline_gen_lm=outline_lm)
+        if draft_module is None:
+            from knowledge_storm.storm_wiki.modules.article_generation import (
+                StormArticleGenerationModule,
+            )
+
+            draft_module = StormArticleGenerationModule(article_gen_lm=draft_lm)
+        if polish_module is None:
+            from knowledge_storm.storm_wiki.modules.article_polish import (
+                StormArticlePolishingModule,
+            )
+
+            polish_module = StormArticlePolishingModule(
+                article_gen_lm=draft_lm, article_polish_lm=polish_lm
+            )
+
+        self.outline_module = outline_module
+        self.draft_module = draft_module
+        self.polish_module = polish_module
+
+    def __call__(
+        self,
+        topic: str,
+        information_table,
+        *,
+        remove_duplicate: bool = False,
+        callback_handler: Optional[object] = None,
+    ):
+        outline = self.outline_module.generate_outline(
+            topic=topic,
+            information_table=information_table,
+            callback_handler=callback_handler,
+        )
+        draft = self.draft_module.generate_article(
+            topic=topic,
+            information_table=information_table,
+            article_with_outline=outline,
+            callback_handler=callback_handler,
+        )
+        article = self.polish_module.polish_article(
+            topic=topic, draft_article=draft, remove_duplicate=remove_duplicate
+        )
+        return article


### PR DESCRIPTION
## Summary
- add `ResearchSkill` wrapper and expose from DSP subpackage
- include simple DSPy evaluation datasets
- document ResearchSkill API example in README
- test ResearchSkill using stubbed modules
- fix tests path import

## Testing
- `pre-commit run --files tino_storm/dsp/skill.py tino_storm/dsp/__init__.py README.md research/example_vault/eval.jsonl research/another_vault/eval.jsonl tests/test_research_skill.py tests/test_config.py`

------
https://chatgpt.com/codex/tasks/task_e_687048122c3c83269091bb9a88a2396e