### PR TITLE
Add Storm and CLI tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -23,4 +23,4 @@ jobs:
           pip install -r requirements.txt
       - name: Run tests
         run: |
-          PYTHONPATH=. pytest -vv
+          PYTHONPATH=. pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,15 +32,61 @@ def pytest_configure(config):
     class STORMWikiLMConfigs:
         def __init__(self):
             self.conv_simulator_lm = None
+            self.question_asker_lm = None
+            self.outline_gen_lm = None
+            self.article_gen_lm = None
+            self.article_polish_lm = None
 
         def set_conv_simulator_lm(self, lm):
             self.conv_simulator_lm = lm
+
+        def set_question_asker_lm(self, lm):
+            self.question_asker_lm = lm
+
+        def set_outline_gen_lm(self, lm):
+            self.outline_gen_lm = lm
+
+        def set_article_gen_lm(self, lm):
+            self.article_gen_lm = lm
+
+        def set_article_polish_lm(self, lm):
+            self.article_polish_lm = lm
 
         def init_check(self):
             pass
 
     engine_mod.STORMWikiRunnerArguments = STORMWikiRunnerArguments
     engine_mod.STORMWikiLMConfigs = STORMWikiLMConfigs
+    ks.STORMWikiRunnerArguments = STORMWikiRunnerArguments
+    ks.STORMWikiLMConfigs = STORMWikiLMConfigs
+
+    class STORMWikiRunner:
+        def __init__(self, args, lm_configs, rm):
+            self.args = args
+            self.lm_configs = lm_configs
+            self.rm = rm
+            self.calls = []
+
+        def build_outline(self, topic, ground_truth_url="", callback_handler=None):
+            self.calls.append(("build_outline", topic, ground_truth_url))
+            return f"outline:{topic}"
+
+        def generate_article(self, callback_handler=None):
+            self.calls.append(("generate_article",))
+            return "article"
+
+        def polish_article(self, remove_duplicate=False):
+            self.calls.append(("polish_article", remove_duplicate))
+            return "polished"
+
+        def post_run(self):
+            self.calls.append(("post_run",))
+
+    class BaseCallbackHandler:
+        pass
+
+    ks.STORMWikiRunner = STORMWikiRunner
+    ks.BaseCallbackHandler = BaseCallbackHandler
 
     storm_wiki_mod = types.ModuleType("knowledge_storm.storm_wiki")
     storm_wiki_mod.engine = engine_mod
@@ -49,7 +95,8 @@ def pytest_configure(config):
     lm_mod = types.ModuleType("knowledge_storm.lm")
 
     class Base:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class LitellmModel(Base):
         def __init__(self, model: str):
@@ -104,34 +151,44 @@ def pytest_configure(config):
     rm_mod = types.ModuleType("knowledge_storm.rm")
 
     class YouRM:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class BingSearch:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class BraveRM:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class SerperRM:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class DuckDuckGoSearchRM:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class TavilySearchRM:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class VectorRM:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class SearXNG:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class AzureAISearch:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     class StanfordOvalArxivRM:
-        pass
+        def __init__(self, *args, **kwargs):
+            pass
 
     for cls in [
         YouRM,
@@ -147,12 +204,21 @@ def pytest_configure(config):
     ]:
         setattr(rm_mod, cls.__name__, cls)
 
+    utils_mod = types.ModuleType("knowledge_storm.utils")
+
+    def load_api_key(toml_file_path: str):
+        return None
+
+    utils_mod.load_api_key = load_api_key
+
     ks.storm_wiki = storm_wiki_mod
     ks.lm = lm_mod
     ks.rm = rm_mod
+    ks.utils = utils_mod
 
     sys.modules["knowledge_storm"] = ks
     sys.modules["knowledge_storm.storm_wiki"] = storm_wiki_mod
     sys.modules["knowledge_storm.storm_wiki.engine"] = engine_mod
     sys.modules["knowledge_storm.lm"] = lm_mod
     sys.modules["knowledge_storm.rm"] = rm_mod
+    sys.modules["knowledge_storm.utils"] = utils_mod

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+import argparse
+from tino_storm.cli import make_config
+
+
+def test_make_config(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("BING_SEARCH_API_KEY", "bing")
+    args = argparse.Namespace(
+        output_dir="out",
+        max_conv_turn=2,
+        max_perspective=4,
+        search_top_k=5,
+        retrieve_top_k=5,
+        max_thread_num=1,
+        retriever="bing",
+    )
+    cfg = make_config(args)
+
+    assert cfg.args.output_dir == "out"
+    assert cfg.args.max_conv_turn == 2
+    assert cfg.lm_configs.conv_simulator_lm is not None
+    assert cfg.rm.__class__.__name__ == "BingSearch"

--- a/tests/test_storm.py
+++ b/tests/test_storm.py
@@ -1,0 +1,40 @@
+from tino_storm.storm import Storm
+from tino_storm.config import StormConfig
+from knowledge_storm.storm_wiki.engine import (
+    STORMWikiRunnerArguments,
+    STORMWikiLMConfigs,
+)
+from knowledge_storm.rm import BingSearch
+
+
+class DummyRM(BingSearch):
+    pass
+
+
+def make_config():
+    args = STORMWikiRunnerArguments(output_dir="out")
+    lm_cfgs = STORMWikiLMConfigs()
+    return StormConfig(args=args, lm_configs=lm_cfgs, rm=DummyRM())
+
+
+def test_build_outline_calls_runner(monkeypatch):
+    cfg = make_config()
+    storm = Storm(cfg)
+    result = storm.build_outline("topic", "url")
+
+    assert result == "outline:topic"
+    assert storm.runner.calls == [("build_outline", "topic", "url")]
+
+
+def test_run_pipeline_sequence(monkeypatch):
+    cfg = make_config()
+    storm = Storm(cfg)
+    article = storm.run_pipeline("topic", "url", remove_duplicate=True)
+
+    assert article == "polished"
+    assert storm.runner.calls == [
+        ("build_outline", "topic", "url"),
+        ("generate_article",),
+        ("polish_article", True),
+        ("post_run",),
+    ]


### PR DESCRIPTION
## Summary
- stub `knowledge_storm` additional classes in tests
- add unit tests for `make_config` and `Storm`
- call `pytest` without `-vv` in CI

## Testing
- `ruff check tino_storm tests`
- `black tino_storm tests -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687048129e34832684368947cad60194