### PR TITLE
Add RRFRetriever improvements

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import sys
 import types
 import importlib.machinery
 from dataclasses import dataclass
+from pathlib import Path
 
 # Stub modules from knowledge_storm to avoid heavy dependencies in tests
 
@@ -9,6 +10,8 @@ from dataclasses import dataclass
 def pytest_configure(config):
     if "knowledge_storm" in sys.modules:
         return
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
     ks = types.ModuleType("knowledge_storm")
     ks.__spec__ = importlib.machinery.ModuleSpec(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -3,6 +3,7 @@ import pytest
 from tino_storm.providers import get_llm, get_retriever
 from knowledge_storm.lm import OpenAIModel
 from knowledge_storm.rm import YouRM
+from tino_storm.rrf import RRFRetriever
 
 
 def test_get_llm_valid():
@@ -16,6 +17,10 @@ def test_get_llm_invalid():
 
 def test_get_retriever_valid():
     assert get_retriever("you") is YouRM
+
+
+def test_get_rrf_retriever_valid():
+    assert get_retriever("rrf") is RRFRetriever
 
 
 def test_get_retriever_invalid():

--- a/tests/test_rrf_retriever.py
+++ b/tests/test_rrf_retriever.py
@@ -1,0 +1,31 @@
+from tino_storm.rrf import RRFRetriever
+
+
+class DummyA:
+    def forward(self, query, exclude_urls=None):
+        return [
+            {"url": "a", "title": "A"},
+            {"url": "b", "title": "B"},
+        ]
+
+
+class DummyB:
+    def forward(self, query, exclude_urls=None):
+        return [
+            {"url": "b", "title": "B"},
+            {"url": "c", "title": "C"},
+        ]
+
+
+def test_rrf_ranking_order():
+    retriever = RRFRetriever([DummyA(), DummyB()], k=0)
+    results = retriever.forward("test")
+    urls = [r["url"] for r in results]
+    assert urls == ["b", "a", "c"]
+
+
+def test_rrf_exclude_urls():
+    retriever = RRFRetriever([DummyA(), DummyB()], k=0)
+    results = retriever.forward("test", exclude_urls=["b"])
+    urls = [r["url"] for r in results]
+    assert urls == ["a", "c"]

--- a/tino_storm/providers/retriever.py
+++ b/tino_storm/providers/retriever.py
@@ -21,6 +21,7 @@ RETRIEVER_REGISTRY: dict[str, str] = {
     "searxng": "SearXNG",
     "azure_ai_search": "AzureAISearch",
     "arxiv": "StanfordOvalArxivRM",
+    "rrf": "RRFRetriever",
 }
 
 
@@ -29,5 +30,9 @@ def get_retriever(name: str) -> Type:
     key = name.lower()
     if key not in RETRIEVER_REGISTRY:
         raise ValueError(f"Unknown retriever provider: {name}")
+    if key == "rrf":
+        from tino_storm.rrf import RRFRetriever
+
+        return RRFRetriever
     module = importlib.import_module("knowledge_storm.rm")
     return getattr(module, RETRIEVER_REGISTRY[key])

--- a/tino_storm/rrf.py
+++ b/tino_storm/rrf.py
@@ -1,0 +1,41 @@
+"""Utilities for reciprocal rank fusion of multiple retrievers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping
+
+
+@dataclass
+class RRFRetriever:
+    """Combine results from multiple retrievers using Reciprocal Rank Fusion (RRF)."""
+
+    retrievers: Iterable
+    k: int = 60
+    top_n: int | None = None
+
+    def __post_init__(self) -> None:
+        """Ensure retrievers is stored as a list."""
+        self.retrievers = list(self.retrievers)
+
+    def forward(self, query: str, exclude_urls: List[str] | None = None) -> List[Mapping]:
+        """Return fused search results for ``query``."""
+
+        exclude_urls = set(exclude_urls or [])
+
+        scores: dict[str, dict[str, float | Mapping]] = {}
+        for retriever in self.retrievers:
+            results = retriever.forward(query, exclude_urls=exclude_urls)
+            for rank, result in enumerate(results):
+                url = result.get("url")
+                if not url or url in exclude_urls:
+                    continue
+                if url not in scores:
+                    scores[url] = {"score": 0.0, "result": result}
+                scores[url]["score"] += 1.0 / (rank + 1 + self.k)
+
+        ranked = sorted(scores.values(), key=lambda x: x["score"], reverse=True)
+        fused = [entry["result"] for entry in ranked]
+        if self.top_n is not None:
+            fused = fused[: self.top_n]
+        return fused


### PR DESCRIPTION
## Summary
- enhance `RRFRetriever` as a dataclass and handle missing/ignored URLs
- test exclude filter behaviour

## Testing
- `ruff check tino_storm tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68704810d7808326a518dea8001627be