### PR TITLE
Improve CoStormRunner config loading

### DIFF
--- a/knowledge_storm/collaborative_storm/engine.py
+++ b/knowledge_storm/collaborative_storm/engine.py
@@ -186,6 +186,16 @@ class CollaborativeStormLMConfigs(LMConfigs):
         return config_dict
 
 
+    @classmethod
+    def from_dict(cls, data: Dict[str, Dict]) -> "CollaborativeStormLMConfigs":
+        """Load :class:`CollaborativeStormLMConfigs` from a dictionary."""
+        lm_config = cls()
+        for attr_name, lm_kwargs in data.items():
+            if hasattr(lm_config, attr_name):
+                setattr(lm_config, attr_name, LitellmModel(**lm_kwargs))
+        return lm_config
+
+
 @dataclass
 class RunnerArgument:
     """Arguments for controlling the STORM Wiki pipeline."""
@@ -558,9 +568,7 @@ class CoStormRunner:
 
     @classmethod
     def from_dict(cls, data, callback_handler: BaseCallbackHandler = None):
-        # FIXME: does not use the lm_config data but naively use default setting
-        lm_config = CollaborativeStormLMConfigs()
-        lm_config.init(lm_type=os.getenv("OPENAI_API_TYPE"))
+        lm_config = CollaborativeStormLMConfigs.from_dict(data["lm_config"])
         costorm_runner = cls(
             lm_config=lm_config,
             runner_argument=RunnerArgument.from_dict(data["runner_argument"]),

--- a/tests/test_costorm_runner.py
+++ b/tests/test_costorm_runner.py
@@ -1,0 +1,49 @@
+from knowledge_storm.collaborative_storm.engine import (
+    CollaborativeStormLMConfigs,
+    RunnerArgument,
+    CoStormRunner,
+)
+from knowledge_storm.lm import LitellmModel
+from knowledge_storm.logging_wrapper import LoggingWrapper
+
+
+def _make_lm_config():
+    cfg = CollaborativeStormLMConfigs()
+    cfg.set_question_answering_lm(LitellmModel(model="qa"))
+    cfg.set_discourse_manage_lm(LitellmModel(model="dm"))
+    cfg.set_utterance_polishing_lm(LitellmModel(model="up"))
+    cfg.set_warmstart_outline_gen_lm(LitellmModel(model="wo"))
+    cfg.set_question_asking_lm(LitellmModel(model="ask"))
+    cfg.set_knowledge_base_lm(LitellmModel(model="kb"))
+    return cfg
+
+
+def test_from_dict_loads_lm_config():
+    lm_config = _make_lm_config()
+    args = RunnerArgument(topic="t")
+    runner = CoStormRunner(
+        lm_config=lm_config,
+        runner_argument=args,
+        logging_wrapper=LoggingWrapper(lm_config),
+    )
+
+    data = {
+        "runner_argument": args.to_dict(),
+        "lm_config": {
+            "question_answering_lm": {"model": "qa"},
+            "discourse_manage_lm": {"model": "dm"},
+            "utterance_polishing_lm": {"model": "up"},
+            "warmstart_outline_gen_lm": {"model": "wo"},
+            "question_asking_lm": {"model": "ask"},
+            "knowledge_base_lm": {"model": "kb"},
+        },
+        "conversation_history": [],
+        "warmstart_conv_archive": [],
+        "experts": [],
+        "knowledge_base": runner.knowledge_base.to_dict(),
+    }
+
+    new_runner = CoStormRunner.from_dict(data)
+    assert new_runner.lm_config.question_answering_lm.model == "qa"
+    assert new_runner.lm_config.discourse_manage_lm.model == "dm"
+    assert new_runner.lm_config.knowledge_base_lm.model == "kb"


### PR DESCRIPTION
## Summary
- allow `CollaborativeStormLMConfigs` to be recreated from a dict
- load saved LM settings in `CoStormRunner.from_dict`
- stub collaborative STORM modules for tests
- stub `dspy` and `requests` modules for tests
- test that LM config is correctly loaded when recreating a runner

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6870626e399c83269ab21bc9776dd731