### PR TITLE
Update RRF exclude url handling

### DIFF
--- a/src/tino_storm/rrf.py
+++ b/src/tino_storm/rrf.py
@@ -19,7 +19,7 @@ class RRFRetriever:
         self.retrievers = list(self.retrievers)
 
     def forward(
-        self, query: str, exclude_urls: List[str] | None = None
+        self, query: str, exclude_urls: Iterable[str] | None = None
     ) -> List[Mapping]:
         """Return fused search results for ``query``."""
 
@@ -27,7 +27,7 @@ class RRFRetriever:
 
         scores: dict[str, dict[str, float | Mapping]] = {}
         for retriever in self.retrievers:
-            results = retriever.forward(query, exclude_urls=exclude_urls)
+            results = retriever.forward(query, exclude_urls=list(exclude_urls))
             for rank, result in enumerate(results):
                 url = result.get("url")
                 if not url or url in exclude_urls:

--- a/tests/test_rrf_retriever.py
+++ b/tests/test_rrf_retriever.py
@@ -29,3 +29,10 @@ def test_rrf_exclude_urls():
     results = retriever.forward("test", exclude_urls=["b"])
     urls = [r["url"] for r in results]
     assert urls == ["a", "c"]
+
+
+def test_rrf_exclude_urls_iterable_equivalence():
+    retriever = RRFRetriever([DummyA(), DummyB()], k=0)
+    results_list = retriever.forward("test", exclude_urls=["b"])
+    results_set = retriever.forward("test", exclude_urls={"b"})
+    assert results_list == results_set


### PR DESCRIPTION
## Summary
- allow `RRFRetriever` to accept any iterable of URLs for exclusion
- pass a list of excluded URLs to component retrievers
- ensure list and set inputs produce the same results

## Testing
- `pre-commit run --files src/tino_storm/rrf.py tests/test_rrf_retriever.py`
- `pytest -q tests/test_rrf_retriever.py`

------
https://chatgpt.com/codex/tasks/task_e_68713ef943e08326ad2f3ea2689cac86