### PR TITLE
Add Ruff step to tests workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,6 +21,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Run Ruff
+        run: |
+          pip install ruff
+          ruff check src/knowledge_storm src/tino_storm tests
       - name: Run tests
         run: |
           PYTHONPATH=. pytest


### PR DESCRIPTION
## Summary
- run `ruff check` prior to running pytest in GitHub Actions

## Testing
- `ruff check src/knowledge_storm src/tino_storm tests`
- `black --check src/knowledge_storm src/tino_storm tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871431f601c8326aef4b9051a22a97b