### PR TITLE
Add CLI topic argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ article = skill("Deep learning", table)
 
 ## CLI usage
 
-After installation, an entrypoint named ``tino-storm`` is available. Run the pipeline interactively with:
+After installation, an entrypoint named ``tino-storm`` is available. Run the pipeline from the command line with:
 
 ```bash
-tino-storm run --retriever bing
+tino-storm run --retriever bing --topic "Quantum computing"
 ```
 
-The command prompts for a topic and prints the generated article. Pass ``--help`` to see all options.
+The command prints the generated article. Omit ``--topic`` to be prompted interactively or pass it to run non-interactively. Use ``--help`` to see all options.
 
 `OPENAI_API_KEY` and `BING_SEARCH_API_KEY` must be set in the environment (or provided via ``secrets.toml``).
 

--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -89,7 +89,7 @@ def make_config(args: argparse.Namespace | None = None) -> StormConfig:
 def _run_storm(args: argparse.Namespace) -> None:
     config = make_config(args)
     storm = Storm(config)
-    topic = input("Topic: ")
+    topic = args.topic or input("Topic: ")
     article = storm.run_pipeline(topic, remove_duplicate=args.remove_duplicate)
     print(article)
 
@@ -133,6 +133,13 @@ def main(argv: list[str] | None = None) -> None:
     run_parser.add_argument("--retrieve-top-k", type=int, default=3)
     run_parser.add_argument(
         "--remove-duplicate", action="store_true", help="Remove duplicate text"
+    )
+    run_parser.add_argument(
+        "--topic",
+        "-t",
+        type=str,
+        default=None,
+        help="Topic to research. Prompted if omitted",
     )
     run_parser.set_defaults(func=_run_storm)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,11 @@
 import argparse
-from tino_storm.cli import make_config
+from tino_storm.cli import make_config, main
+from tino_storm.storm import Storm
+
+
+def _setup_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("BING_SEARCH_API_KEY", "bing")
 
 
 def test_make_config(monkeypatch):
@@ -20,3 +26,32 @@ def test_make_config(monkeypatch):
     assert cfg.args.max_conv_turn == 2
     assert cfg.lm_configs.conv_simulator_lm is not None
     assert cfg.rm.__class__.__name__ == "BingSearch"
+
+
+def test_run_uses_topic_arg(monkeypatch):
+    _setup_env(monkeypatch)
+    recorded = {}
+
+    def run_pipeline(self, topic: str, ground_truth_url: str = "", remove_duplicate: bool = False):
+        recorded["topic"] = topic
+        return "article"
+
+    monkeypatch.setattr(Storm, "run_pipeline", run_pipeline)
+    main(["run", "--retriever", "bing", "--topic", "cats"])
+
+    assert recorded["topic"] == "cats"
+
+
+def test_run_prompts_for_topic(monkeypatch):
+    _setup_env(monkeypatch)
+    recorded = {}
+
+    def run_pipeline(self, topic: str, ground_truth_url: str = "", remove_duplicate: bool = False):
+        recorded["topic"] = topic
+        return "article"
+
+    monkeypatch.setattr(Storm, "run_pipeline", run_pipeline)
+    monkeypatch.setattr("builtins.input", lambda _: "dogs")
+    main(["run", "--retriever", "bing"])
+
+    assert recorded["topic"] == "dogs"


### PR DESCRIPTION
## Summary
- add optional topic argument to run subcommand
- document topic argument in README
- test CLI run with and without `--topic`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c36352948326889e1ca2e23051e3