### PR TITLE
Delegate Storm creation to from_env

### DIFF
--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
 import argparse
-import os
-
-
-from .config import StormConfig
-from .providers import get_retriever
+from .config import StormConfig, create_retriever
 from .storm import Storm
 
 
@@ -16,74 +12,19 @@ def make_config(args: argparse.Namespace | None = None) -> StormConfig:
     """
     if args is None:
         return StormConfig.from_env()
-    from knowledge_storm import (
-        STORMWikiRunnerArguments,
-        STORMWikiLMConfigs,
-    )
-    from knowledge_storm.lm import OpenAIModel, AzureOpenAIModel
-    from knowledge_storm.utils import load_api_key
 
-    load_api_key(toml_file_path="secrets.toml")
+    config = StormConfig.from_env()
 
-    openai_type = os.getenv("OPENAI_API_TYPE", "openai")
-    openai_kwargs = {
-        "api_key": os.getenv("OPENAI_API_KEY"),
-        "temperature": 1.0,
-        "top_p": 0.9,
-    }
-    if openai_type == "azure":
-        openai_kwargs["api_base"] = os.getenv("AZURE_API_BASE")
-        openai_kwargs["api_version"] = os.getenv("AZURE_API_VERSION")
+    config.args.output_dir = args.output_dir
+    config.args.max_conv_turn = args.max_conv_turn
+    config.args.max_perspective = args.max_perspective
+    config.args.search_top_k = args.search_top_k
+    config.args.max_thread_num = args.max_thread_num
+    config.args.retrieve_top_k = args.retrieve_top_k
 
-    model_cls = OpenAIModel if openai_type == "openai" else AzureOpenAIModel
-    gpt_35 = "gpt-3.5-turbo" if openai_type == "openai" else "gpt-35-turbo"
-    gpt_4 = "gpt-4o"
+    config.rm = create_retriever(args.retriever, config.args.search_top_k)
 
-    conv_simulator_lm = model_cls(model=gpt_35, max_tokens=500, **openai_kwargs)
-    question_asker_lm = model_cls(model=gpt_35, max_tokens=500, **openai_kwargs)
-    outline_gen_lm = model_cls(model=gpt_4, max_tokens=400, **openai_kwargs)
-    article_gen_lm = model_cls(model=gpt_4, max_tokens=700, **openai_kwargs)
-    article_polish_lm = model_cls(model=gpt_4, max_tokens=4000, **openai_kwargs)
-
-    lm_configs = STORMWikiLMConfigs()
-    lm_configs.set_conv_simulator_lm(conv_simulator_lm)
-    lm_configs.set_question_asker_lm(question_asker_lm)
-    lm_configs.set_outline_gen_lm(outline_gen_lm)
-    lm_configs.set_article_gen_lm(article_gen_lm)
-    lm_configs.set_article_polish_lm(article_polish_lm)
-
-    engine_args = STORMWikiRunnerArguments(
-        output_dir=args.output_dir,
-        max_conv_turn=args.max_conv_turn,
-        max_perspective=args.max_perspective,
-        search_top_k=args.search_top_k,
-        max_thread_num=args.max_thread_num,
-        retrieve_top_k=args.retrieve_top_k,
-    )
-
-    rm_cls = get_retriever(args.retriever)
-    rm_kwargs = {"k": engine_args.search_top_k}
-    if args.retriever == "bing":
-        rm_kwargs["bing_search_api_key"] = os.getenv("BING_SEARCH_API_KEY")
-    elif args.retriever == "you":
-        rm_kwargs["ydc_api_key"] = os.getenv("YDC_API_KEY")
-    elif args.retriever == "brave":
-        rm_kwargs["brave_search_api_key"] = os.getenv("BRAVE_API_KEY")
-    elif args.retriever == "duckduckgo":
-        rm_kwargs.update({"safe_search": "On", "region": "us-en"})
-    elif args.retriever == "serper":
-        rm_kwargs["serper_search_api_key"] = os.getenv("SERPER_API_KEY")
-        rm_kwargs["query_params"] = {"autocorrect": True, "num": 10, "page": 1}
-    elif args.retriever == "tavily":
-        rm_kwargs["tavily_search_api_key"] = os.getenv("TAVILY_API_KEY")
-        rm_kwargs["include_raw_content"] = True
-    elif args.retriever == "searxng":
-        rm_kwargs["searxng_api_key"] = os.getenv("SEARXNG_API_KEY")
-    elif args.retriever == "azure_ai_search":
-        rm_kwargs["azure_ai_search_api_key"] = os.getenv("AZURE_AI_SEARCH_API_KEY")
-    rm = rm_cls(**rm_kwargs)
-
-    return StormConfig(engine_args, lm_configs, rm)
+    return config
 
 
 def _run_storm(args: argparse.Namespace) -> None:

--- a/src/tino_storm/fastapi_app.py
+++ b/src/tino_storm/fastapi_app.py
@@ -2,15 +2,10 @@
 
 from __future__ import annotations
 
-import os
-
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from knowledge_storm import STORMWikiRunnerArguments, STORMWikiLMConfigs
-from knowledge_storm.rm import DuckDuckGoSearchRM
-
-from .config import StormConfig
+from .config import StormConfig, create_retriever
 from .storm import Storm
 
 
@@ -22,23 +17,15 @@ class OutlineRequest(BaseModel):
     ground_truth_url: str | None = None
 
 
-def _create_storm() -> Storm:
-    """Create a :class:`Storm` instance with default configuration."""
-    args = STORMWikiRunnerArguments(
-        output_dir=os.getenv("STORM_OUTPUT_DIR", "storm_output")
-    )
-    lm_configs = STORMWikiLMConfigs()
-    openai_key = os.getenv("OPENAI_API_KEY")
-    if openai_key:
-        lm_configs.init_openai_model(
-            openai_api_key=openai_key,
-            azure_api_key=os.getenv("AZURE_API_KEY", ""),
-            openai_type=os.getenv("OPENAI_API_TYPE", "openai"),
-            api_base=os.getenv("AZURE_API_BASE"),
-            api_version=os.getenv("AZURE_API_VERSION"),
-        )
-    rm = DuckDuckGoSearchRM(k=args.search_top_k)
-    config = StormConfig(args=args, lm_configs=lm_configs, rm=rm)
+def _create_storm(
+    *, output_dir: str | None = None, retriever: str | None = None
+) -> Storm:
+    """Create a :class:`Storm` instance using :func:`StormConfig.from_env`."""
+    config = StormConfig.from_env()
+    if output_dir is not None:
+        config.args.output_dir = output_dir
+    if retriever is not None:
+        config.rm = create_retriever(retriever, config.args.search_top_k)
     return Storm(config)
 
 


### PR DESCRIPTION
## Summary
- create a helper `create_retriever` for constructing retrievers from env vars
- refactor `StormConfig.from_env` to use the helper
- simplify CLI `make_config` using `StormConfig.from_env`
- update FastAPI `_create_storm` to use the new config builder

## Testing
- `ruff check src/tino_storm/cli.py src/tino_storm/config.py src/tino_storm/fastapi_app.py`
- `black src/tino_storm/cli.py src/tino_storm/config.py src/tino_storm/fastapi_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c729abd08326b3f15c452390cbaf