### PR TITLE
Expose Storm utilities at package level

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A minimal example for generating an article is shown below.
 ```python
 import os
 from knowledge_storm import STORMWikiRunnerArguments, STORMWikiRunner, STORMWikiLMConfigs
-from tino_storm.providers import get_llm, get_retriever
+from tino_storm import get_llm, get_retriever
 
 args = STORMWikiRunnerArguments()
 lm_configs = STORMWikiLMConfigs()
@@ -98,7 +98,7 @@ The CLI loads this file automatically so you don't need to export the variables 
 You can programmatically create the same configuration using:
 
 ```python
-from tino_storm.config import StormConfig
+from tino_storm import StormConfig
 
 config = StormConfig.from_env()
 ```

--- a/examples/cli_example.py
+++ b/examples/cli_example.py
@@ -8,7 +8,7 @@ from knowledge_storm import (
     STORMWikiRunner,
     STORMWikiLMConfigs,
 )
-from tino_storm.providers import get_llm, get_retriever
+from tino_storm import get_llm, get_retriever
 
 
 def run(topic: str) -> None:

--- a/examples/costorm_examples/run_costorm_gpt.py
+++ b/examples/costorm_examples/run_costorm_gpt.py
@@ -26,7 +26,7 @@ from knowledge_storm.collaborative_storm.modules.callback import (
 )
 from knowledge_storm.lm import OpenAIModel, AzureOpenAIModel
 from knowledge_storm.logging_wrapper import LoggingWrapper
-from tino_storm.providers import get_retriever
+from tino_storm import get_retriever
 from knowledge_storm.utils import load_api_key
 
 

--- a/examples/fastapi_example.py
+++ b/examples/fastapi_example.py
@@ -9,7 +9,7 @@ from knowledge_storm import (
     STORMWikiRunner,
     STORMWikiLMConfigs,
 )
-from tino_storm.providers import get_llm, get_retriever
+from tino_storm import get_llm, get_retriever
 
 
 class Request(BaseModel):

--- a/examples/import_example.py
+++ b/examples/import_example.py
@@ -6,7 +6,7 @@ from knowledge_storm import (
     STORMWikiRunner,
     STORMWikiLMConfigs,
 )
-from tino_storm.providers import get_llm, get_retriever
+from tino_storm import get_llm, get_retriever
 
 
 def main() -> None:

--- a/examples/storm_examples/run_storm_wiki_claude.py
+++ b/examples/storm_examples/run_storm_wiki_claude.py
@@ -25,7 +25,7 @@ from knowledge_storm import (
     STORMWikiLMConfigs,
 )
 from knowledge_storm.lm import ClaudeModel
-from tino_storm.providers import get_retriever
+from tino_storm import get_retriever
 from knowledge_storm.utils import load_api_key
 
 

--- a/examples/storm_examples/run_storm_wiki_deepseek.py
+++ b/examples/storm_examples/run_storm_wiki_deepseek.py
@@ -28,7 +28,7 @@ from knowledge_storm import (
     STORMWikiLMConfigs,
 )
 from knowledge_storm.lm import DeepSeekModel
-from tino_storm.providers import get_retriever
+from tino_storm import get_retriever
 from knowledge_storm.utils import load_api_key
 
 

--- a/examples/storm_examples/run_storm_wiki_gemini.py
+++ b/examples/storm_examples/run_storm_wiki_gemini.py
@@ -25,7 +25,7 @@ from knowledge_storm import (
     STORMWikiLMConfigs,
 )
 from knowledge_storm.lm import GoogleModel
-from tino_storm.providers import get_retriever
+from tino_storm import get_retriever
 from knowledge_storm.utils import load_api_key
 
 

--- a/examples/storm_examples/run_storm_wiki_gpt.py
+++ b/examples/storm_examples/run_storm_wiki_gpt.py
@@ -28,7 +28,7 @@ from knowledge_storm import (
     STORMWikiLMConfigs,
 )
 from knowledge_storm.lm import OpenAIModel, AzureOpenAIModel
-from tino_storm.providers import get_retriever
+from tino_storm import get_retriever
 from knowledge_storm.utils import load_api_key
 
 

--- a/examples/storm_examples/run_storm_wiki_groq.py
+++ b/examples/storm_examples/run_storm_wiki_groq.py
@@ -30,7 +30,7 @@ from knowledge_storm import (
 
 # Now import lm directly
 from lm import GroqModel
-from tino_storm.providers import get_retriever
+from tino_storm import get_retriever
 from knowledge_storm.utils import load_api_key
 
 logger = logging.getLogger(__name__)

--- a/examples/storm_examples/run_storm_wiki_mistral.py
+++ b/examples/storm_examples/run_storm_wiki_mistral.py
@@ -27,7 +27,7 @@ from knowledge_storm import (
     STORMWikiLMConfigs,
 )
 from knowledge_storm.lm import VLLMClient
-from tino_storm.providers import get_retriever
+from tino_storm import get_retriever
 from knowledge_storm.utils import load_api_key
 
 

--- a/examples/storm_examples/run_storm_wiki_ollama.py
+++ b/examples/storm_examples/run_storm_wiki_ollama.py
@@ -22,7 +22,7 @@ from argparse import ArgumentParser
 from dspy import Example
 
 from knowledge_storm.lm import OllamaClient
-from tino_storm.providers import get_retriever
+from tino_storm import get_retriever
 from knowledge_storm import (
     STORMWikiRunnerArguments,
     STORMWikiRunner,

--- a/src/tino_storm/__init__.py
+++ b/src/tino_storm/__init__.py
@@ -1,3 +1,11 @@
 from __future__ import annotations
 
+from .config import StormConfig
+from .providers import get_llm, get_retriever
+from .storm import Storm
+
+"""Public interface for the :mod:`tino_storm` package."""
+
 __version__ = "0.1.0"
+
+__all__ = ["Storm", "StormConfig", "get_llm", "get_retriever"]


### PR DESCRIPTION
## Summary
- expose `Storm`, `StormConfig` and provider helpers from `tino_storm`
- update README to use new import path
- update example scripts to import helpers from the package root

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c729f42c8326b2c8d9645ebb06ee