### PR TITLE
Improve docs and add module docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,14 @@ pip install .
 The `tino_storm` package provides a thin wrapper around the original `knowledge_storm` modules.
 A minimal example for generating an article is shown below.
 
+
 ```python
 import os
-from knowledge_storm import STORMWikiRunnerArguments, STORMWikiRunner, STORMWikiLMConfigs
+from knowledge_storm import (
+    STORMWikiRunnerArguments,
+    STORMWikiRunner,
+    STORMWikiLMConfigs,
+)
 from tino_storm import get_llm, get_retriever
 
 args = STORMWikiRunnerArguments()
@@ -50,6 +55,20 @@ lm_configs.set_article_gen_lm(openai_lm)
 rm = Retriever(bing_search_api_key=os.getenv("BING_SEARCH_API_KEY"), k=args.search_top_k)
 runner = STORMWikiRunner(args, lm_configs, rm)
 article = runner.run(topic="Deep learning", do_research=True, do_generate_outline=True, do_generate_article=True)
+print(article)
+```
+
+## Python API
+
+The high-level :class:`~tino_storm.storm.Storm` class provides a minimal wrapper
+around ``knowledge_storm``. Instantiate it with a :class:`StormConfig` and call
+``run_pipeline``:
+
+```python
+from tino_storm import Storm, StormConfig
+
+config = StormConfig.from_env()
+article = Storm(config).run_pipeline(topic="Deep learning")
 print(article)
 ```
 

--- a/src/tino_storm/ingest/watchdog.py
+++ b/src/tino_storm/ingest/watchdog.py
@@ -1,4 +1,4 @@
-"""File system watcher for ingesting research files."""
+"""Watch a research vault for new files and index them."""
 
 from __future__ import annotations
 

--- a/src/tino_storm/loaders/__init__.py
+++ b/src/tino_storm/loaders/__init__.py
@@ -1,4 +1,4 @@
-"""Utility functions for scraping URLs listed in manifests."""
+"""Loader helpers for scraping supported URLs."""
 
 from __future__ import annotations
 

--- a/src/tino_storm/storm.py
+++ b/src/tino_storm/storm.py
@@ -1,3 +1,5 @@
+"""High-level interface for running the STORM pipeline."""
+
 from __future__ import annotations
 
 from typing import Optional, TYPE_CHECKING


### PR DESCRIPTION
## Summary
- add module docstrings for loaders, ingest watchdog and Storm
- document a simple Python API in the README

## Testing
- `pre-commit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871d320822c832697a3eb9d88def3ea