### PR TITLE
Update fastapi retriever config

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,16 @@ This helper reads the environment (or ``secrets.toml``) for API keys and optiona
 ``STORM_RETRIEVER`` or ``STORM_OUTPUT_DIR``. It then sets up the default LLMs and retriever so you
 can immediately run a pipeline:
 
+
 ```python
 article = config.run(topic="Quantum computing")
 ```
+
+### Environment variables
+
+The ``tino_storm.fastapi_app`` module also consults ``STORM_RETRIEVER`` to
+select the search backend. Set this variable to one of the supported providers,
+for example ``bing`` or ``serper``.
 
 ## Ingesting research data
 

--- a/src/tino_storm/fastapi_app.py
+++ b/src/tino_storm/fastapi_app.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from .config import StormConfig, create_retriever
+from .config import StormConfig
+from .providers import get_retriever
 from .storm import Storm
 
 
@@ -24,8 +25,13 @@ def _create_storm(
     config = StormConfig.from_env()
     if output_dir is not None:
         config.args.output_dir = output_dir
+    if retriever is None:
+        import os
+
+        retriever = os.getenv("STORM_RETRIEVER")
     if retriever is not None:
-        config.rm = create_retriever(retriever, config.args.search_top_k)
+        rm_cls = get_retriever(retriever)
+        config.rm = rm_cls(k=config.args.search_top_k)
     return Storm(config)
 
 


### PR DESCRIPTION
## Summary
- support `STORM_RETRIEVER` in `fastapi_app._create_storm`
- document `STORM_RETRIEVER` in the README

## Testing
- `pre-commit run --files src/tino_storm/fastapi_app.py README.md`

------
https://chatgpt.com/codex/tasks/task_e_6871d319f8508326819aac9775e47a7d