### PR TITLE
Pin httpx to <0.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ scripts = {"tino-storm" = "tino_storm.cli:main"}
 [project.optional-dependencies]
 ollama = ["ollama-python", "litellm"]
 chroma = ["chromadb", "llama-index"]
+fastapi = ["fastapi", "httpx<0.28"]
 
 [tool.setuptools.dynamic]
 version = {attr = "tino_storm.__version__"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ snscrape
 praw
 requests
 pytesseract
+httpx<0.28


### PR DESCRIPTION
## Summary
- pin httpx dependency in requirements
- expose optional fastapi extra that pins the same version

## Testing
- `ruff check src/knowledge_storm src/tino_storm tests`
- `black --check src/knowledge_storm src/tino_storm tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732a8825848326be6e662529b0f58c