### PR TITLE
Add FastAPI optional extra and update CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install '.[fastapi]'
       - name: Run Ruff
         run: |
           pip install ruff

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Install optional dependencies for different backends with:
 ```bash
 pip install 'tino-storm[ollama]'   # Ollama backend
 pip install 'tino-storm[chroma]'   # Chroma-based ingestion
+pip install 'tino-storm[fastapi]'  # FastAPI web server
 ```
 
 Alternatively, install the latest source version from this repository to get the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ scripts = {"tino-storm" = "tino_storm.cli:main"}
 [project.optional-dependencies]
 ollama = ["ollama-python", "litellm"]
 chroma = ["chromadb", "llama-index"]
-fastapi = ["fastapi", "httpx<0.28"]
+fastapi = ["fastapi", "starlette", "httpx<0.28"]
 
 [tool.setuptools.dynamic]
 version = {attr = "tino_storm.__version__"}


### PR DESCRIPTION
## Summary
- include `starlette` in the FastAPI optional dependency group
- list the new `fastapi` extra in README installation instructions
- install the extra in Python tests workflow

## Testing
- `ruff check src/knowledge_storm src/tino_storm tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687332ce737c83269b4f23788ae101a0