### PR TITLE
Add ingest optional extras with watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Install optional dependencies for different backends with:
 pip install 'tino-storm[ollama]'   # Ollama backend
 pip install 'tino-storm[chroma]'   # Chroma-based ingestion
 pip install 'tino-storm[fastapi]'  # FastAPI web server
+pip install 'tino-storm[ingest]'   # File watching for ingestion
 ```
 
 Alternatively, install the latest source version from this repository to get the
@@ -152,7 +153,7 @@ LlamaIndex and stored in `~/.tino_storm/chroma/my_vault` using Chroma as the vec
 dependencies with:
 
 ```bash
-pip install watchdog llama-index chromadb
+pip install 'tino-storm[chroma,ingest]'
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ scripts = {"tino-storm" = "tino_storm.cli:main"}
 ollama = ["ollama-python", "litellm"]
 chroma = ["chromadb", "llama-index"]
 fastapi = ["fastapi", "starlette", "httpx<0.28"]
+ingest = ["watchdog"]
 
 [tool.setuptools.dynamic]
 version = {attr = "tino_storm.__version__"}


### PR DESCRIPTION
## Summary
- add new `ingest` extra with `watchdog`
- document ingestion extra in README

## Testing
- `ruff check src/knowledge_storm src/tino_storm tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68742e2db2648326a53aed48f02e2842