### PR TITLE
Add outline, draft and polish CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,24 @@ After installation, an entrypoint named ``tino-storm`` is available. Run the pip
 tino-storm run --retriever bing --topic "Quantum computing"
 ```
 
+Generate the outline only:
+
+```bash
+tino-storm outline --retriever bing --topic "Quantum computing"
+```
+
+Draft the article from a saved outline:
+
+```bash
+tino-storm draft --retriever bing
+```
+
+Polish an existing draft:
+
+```bash
+tino-storm polish --retriever bing --remove-duplicate
+```
+
 The command prints the generated article. Omit ``--topic`` to be prompted interactively or pass it to run non-interactively. Use ``--help`` to see all options.
 
 `OPENAI_API_KEY` and `BING_SEARCH_API_KEY` must be set in the environment (or provided via ``secrets.toml``).

--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -35,6 +35,28 @@ def _run_storm(args: argparse.Namespace) -> None:
     print(article)
 
 
+def _run_outline(args: argparse.Namespace) -> None:
+    config = make_config(args)
+    storm = Storm(config)
+    topic = args.topic or input("Topic: ")
+    outline = storm.build_outline(topic)
+    print(outline)
+
+
+def _run_draft(args: argparse.Namespace) -> None:
+    config = make_config(args)
+    storm = Storm(config)
+    draft = storm.generate_article()
+    print(draft)
+
+
+def _run_polish(args: argparse.Namespace) -> None:
+    config = make_config(args)
+    storm = Storm(config)
+    article = storm.polish_article(remove_duplicate=args.remove_duplicate)
+    print(article)
+
+
 def _run_ingest(args: argparse.Namespace) -> None:
     from .ingest import watch_vault
 
@@ -83,6 +105,99 @@ def main(argv: list[str] | None = None) -> None:
         help="Topic to research. Prompted if omitted",
     )
     run_parser.set_defaults(func=_run_storm)
+
+    outline_parser = sub.add_parser("outline", help="Generate an outline")
+    outline_parser.add_argument(
+        "--output-dir", type=str, default="./results/cli", help="Directory for outputs"
+    )
+    outline_parser.add_argument(
+        "--max-thread-num", type=int, default=3, help="Maximum number of threads"
+    )
+    outline_parser.add_argument(
+        "--retriever",
+        type=str,
+        required=True,
+        choices=[
+            "bing",
+            "you",
+            "brave",
+            "serper",
+            "duckduckgo",
+            "tavily",
+            "searxng",
+            "azure_ai_search",
+        ],
+        help="Search engine to use",
+    )
+    outline_parser.add_argument("--max-conv-turn", type=int, default=3)
+    outline_parser.add_argument("--max-perspective", type=int, default=3)
+    outline_parser.add_argument("--search-top-k", type=int, default=3)
+    outline_parser.add_argument("--retrieve-top-k", type=int, default=3)
+    outline_parser.add_argument(
+        "--topic", "-t", type=str, default=None, help="Topic to research. Prompted if omitted"
+    )
+    outline_parser.set_defaults(func=_run_outline)
+
+    draft_parser = sub.add_parser("draft", help="Generate an article draft")
+    draft_parser.add_argument(
+        "--output-dir", type=str, default="./results/cli", help="Directory for outputs"
+    )
+    draft_parser.add_argument(
+        "--max-thread-num", type=int, default=3, help="Maximum number of threads"
+    )
+    draft_parser.add_argument(
+        "--retriever",
+        type=str,
+        required=True,
+        choices=[
+            "bing",
+            "you",
+            "brave",
+            "serper",
+            "duckduckgo",
+            "tavily",
+            "searxng",
+            "azure_ai_search",
+        ],
+        help="Search engine to use",
+    )
+    draft_parser.add_argument("--max-conv-turn", type=int, default=3)
+    draft_parser.add_argument("--max-perspective", type=int, default=3)
+    draft_parser.add_argument("--search-top-k", type=int, default=3)
+    draft_parser.add_argument("--retrieve-top-k", type=int, default=3)
+    draft_parser.set_defaults(func=_run_draft)
+
+    polish_parser = sub.add_parser("polish", help="Polish a draft article")
+    polish_parser.add_argument(
+        "--output-dir", type=str, default="./results/cli", help="Directory for outputs"
+    )
+    polish_parser.add_argument(
+        "--max-thread-num", type=int, default=3, help="Maximum number of threads"
+    )
+    polish_parser.add_argument(
+        "--retriever",
+        type=str,
+        required=True,
+        choices=[
+            "bing",
+            "you",
+            "brave",
+            "serper",
+            "duckduckgo",
+            "tavily",
+            "searxng",
+            "azure_ai_search",
+        ],
+        help="Search engine to use",
+    )
+    polish_parser.add_argument("--max-conv-turn", type=int, default=3)
+    polish_parser.add_argument("--max-perspective", type=int, default=3)
+    polish_parser.add_argument("--search-top-k", type=int, default=3)
+    polish_parser.add_argument("--retrieve-top-k", type=int, default=3)
+    polish_parser.add_argument(
+        "--remove-duplicate", action="store_true", help="Remove duplicate text"
+    )
+    polish_parser.set_defaults(func=_run_polish)
 
     ingest_parser = sub.add_parser("ingest", help="Ingest research files")
     ingest_parser.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,3 +76,60 @@ def test_ingest_calls_watch_vault(monkeypatch):
     main(["ingest", "--vault", "v"])
 
     assert recorded["vault"] == "v"
+
+
+def test_outline_uses_topic_arg(monkeypatch):
+    _setup_env(monkeypatch)
+    recorded = {}
+
+    def build_outline(self, topic: str, ground_truth_url: str = "", callback_handler=None):
+        recorded["topic"] = topic
+        return "outline"
+
+    monkeypatch.setattr(Storm, "build_outline", build_outline)
+    main(["outline", "--retriever", "bing", "--topic", "cats"])
+
+    assert recorded["topic"] == "cats"
+
+
+def test_outline_prompts_for_topic(monkeypatch):
+    _setup_env(monkeypatch)
+    recorded = {}
+
+    def build_outline(self, topic: str, ground_truth_url: str = "", callback_handler=None):
+        recorded["topic"] = topic
+        return "outline"
+
+    monkeypatch.setattr(Storm, "build_outline", build_outline)
+    monkeypatch.setattr("builtins.input", lambda _: "dogs")
+    main(["outline", "--retriever", "bing"])
+
+    assert recorded["topic"] == "dogs"
+
+
+def test_draft_calls_generate_article(monkeypatch):
+    _setup_env(monkeypatch)
+    called = {}
+
+    def generate_article(self, callback_handler=None):
+        called["called"] = True
+        return "draft"
+
+    monkeypatch.setattr(Storm, "generate_article", generate_article)
+    main(["draft", "--retriever", "bing"])
+
+    assert called.get("called")
+
+
+def test_polish_calls_polish_article(monkeypatch):
+    _setup_env(monkeypatch)
+    recorded = {}
+
+    def polish_article(self, remove_duplicate: bool = False):
+        recorded["dup"] = remove_duplicate
+        return "polished"
+
+    monkeypatch.setattr(Storm, "polish_article", polish_article)
+    main(["polish", "--retriever", "bing", "--remove-duplicate"])
+
+    assert recorded["dup"] is True


### PR DESCRIPTION
## Summary
- extend CLI with subcommands to run outline, draft and polish steps individually
- document the new commands in the README
- test the new CLI options

## Testing
- `ruff check src/tino_storm tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742e2c3d108326ad5b05d5217cffa0