### PR TITLE
Handle 4channel URLs

### DIFF
--- a/src/tino_storm/loaders/__init__.py
+++ b/src/tino_storm/loaders/__init__.py
@@ -28,7 +28,7 @@ def _choose_loader(url: str):
         from . import reddit
 
         return reddit.fetch_post
-    if "4chan.org" in netloc:
+    if "4chan.org" in netloc or "4channel.org" in netloc:
         from . import chan
 
         return chan.fetch_thread

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -25,6 +25,13 @@ def test_choose_loader_chan():
     )
 
 
+def test_choose_loader_4channel():
+    assert (
+        loaders._choose_loader("https://boards.4channel.org/g/thread/123")
+        is loaders.chan.fetch_thread
+    )
+
+
 def test_load_dispatch(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- support `4channel.org` links in `_choose_loader`
- test `_choose_loader` with 4channel URLs

## Testing
- `pre-commit run --files src/tino_storm/loaders/__init__.py tests/test_loaders.py`

------
https://chatgpt.com/codex/tasks/task_e_687d2686180c8326b1a915d88b905eb4