### PR TITLE
Fix OCR image download context handling

### DIFF
--- a/src/tino_storm/loaders/twitter.py
+++ b/src/tino_storm/loaders/twitter.py
@@ -34,10 +34,10 @@ def _ocr_image(url: str) -> str:
     if not pytesseract or not Image:  # pragma: no cover - optional dependency
         return ""
     try:
-        resp = requests.get(url, timeout=10)
-        resp.raise_for_status()
-        with Image.open(BytesIO(resp.content)) as img:
-            return pytesseract.image_to_string(img)
+        with requests.get(url, timeout=10) as resp:
+            resp.raise_for_status()
+            with Image.open(BytesIO(resp.content)) as img:
+                return pytesseract.image_to_string(img)
     except Exception:
         return ""
 

--- a/tests/test_twitter_ocr.py
+++ b/tests/test_twitter_ocr.py
@@ -1,0 +1,44 @@
+import types
+from tino_storm.loaders import twitter
+
+
+def test_ocr_image_uses_context(monkeypatch):
+    called = {}
+
+    class DummyResp:
+        def __init__(self):
+            self.content = b"img"
+        def raise_for_status(self):
+            called['raise'] = True
+        def __enter__(self):
+            called['enter'] = True
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            called['exit'] = True
+
+    def fake_get(url, timeout=10):
+        called['url'] = url
+        called['timeout'] = timeout
+        return DummyResp()
+
+    monkeypatch.setattr(twitter.requests, "get", fake_get, raising=False)
+
+    class DummyImg:
+        def __enter__(self):
+            called['img_enter'] = True
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            called['img_exit'] = True
+
+    def fake_open(data):
+        called['data'] = data.getvalue()
+        return DummyImg()
+
+    monkeypatch.setattr(twitter, "Image", types.SimpleNamespace(open=fake_open))
+    monkeypatch.setattr(twitter, "pytesseract", types.SimpleNamespace(image_to_string=lambda img: "txt"))
+
+    result = twitter._ocr_image("http://example.com/img")
+    assert result == "txt"
+    assert called['enter'] and called['exit']
+    assert called['img_enter'] and called['img_exit']
+    assert called['data'] == b"img"


### PR DESCRIPTION
## Summary
- ensure `_ocr_image` cleans up HTTP resources by using a `with` statement
- test OCR image reading with a mocked `requests.get`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d268619a48326a00df9fb80c22abc