### PR TITLE
Add cloud provider flag

### DIFF
--- a/src/tino_storm/config.py
+++ b/src/tino_storm/config.py
@@ -46,6 +46,7 @@ class StormConfig:
     args: STORMWikiRunnerArguments
     lm_configs: STORMWikiLMConfigs
     rm: Any
+    cloud_allowed: bool = True
 
     @classmethod
     def from_env(cls) -> "StormConfig":
@@ -67,8 +68,10 @@ class StormConfig:
 
         args = STORMWikiRunnerArguments(output_dir=output_dir)
 
+        cloud_allowed = os.getenv("STORM_CLOUD_ALLOWED", "true").lower() != "false"
+
         openai_type = os.getenv("OPENAI_API_TYPE", "openai")
-        llm_cls = get_llm(openai_type)
+        llm_cls = get_llm(openai_type, cloud_allowed=cloud_allowed)
 
         openai_kwargs = {
             "api_key": os.getenv("OPENAI_API_KEY"),
@@ -97,4 +100,4 @@ class StormConfig:
 
         rm = create_retriever(retriever_name, args.search_top_k)
 
-        return cls(args=args, lm_configs=lm_configs, rm=rm)
+        return cls(args=args, lm_configs=lm_configs, rm=rm, cloud_allowed=cloud_allowed)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import pytest
+
 from tino_storm.config import StormConfig
 from knowledge_storm.storm_wiki.engine import (
     STORMWikiRunnerArguments,
@@ -32,3 +34,24 @@ def test_storm_config_from_env(monkeypatch):
 
     assert cfg.lm_configs.conv_simulator_lm is not None
     assert cfg.rm.__class__.__name__ == "BingSearch"
+    assert cfg.cloud_allowed is True
+
+
+def test_storm_config_cloud_disabled(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("BING_SEARCH_API_KEY", "bing")
+    monkeypatch.setenv("STORM_RETRIEVER", "bing")
+    monkeypatch.setenv("STORM_CLOUD_ALLOWED", "false")
+    monkeypatch.setenv("OPENAI_API_TYPE", "vllm")
+    cfg = StormConfig.from_env()
+
+    assert cfg.cloud_allowed is False
+
+
+def test_storm_config_cloud_block(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk")
+    monkeypatch.setenv("BING_SEARCH_API_KEY", "bing")
+    monkeypatch.setenv("STORM_RETRIEVER", "bing")
+    monkeypatch.setenv("STORM_CLOUD_ALLOWED", "false")
+    with pytest.raises(ValueError):
+        StormConfig.from_env()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,7 +1,7 @@
 import pytest
 
 from tino_storm.providers import get_llm, get_retriever
-from knowledge_storm.lm import OpenAIModel
+from knowledge_storm.lm import OpenAIModel, VLLMClient
 from knowledge_storm.rm import YouRM
 from tino_storm.rrf import RRFRetriever
 
@@ -26,3 +26,14 @@ def test_get_rrf_retriever_valid():
 def test_get_retriever_invalid():
     with pytest.raises(ValueError):
         get_retriever("unknown")
+
+
+def test_get_llm_cloud_disallowed(monkeypatch):
+    monkeypatch.setenv("STORM_CLOUD_ALLOWED", "false")
+    with pytest.raises(ValueError):
+        get_llm("openai")
+
+
+def test_get_llm_non_cloud_allowed(monkeypatch):
+    monkeypatch.setenv("STORM_CLOUD_ALLOWED", "false")
+    assert get_llm("vllm") is VLLMClient


### PR DESCRIPTION
## Summary
- support `STORM_CLOUD_ALLOWED` in `StormConfig.from_env`
- block cloud models in `get_llm` when disabled
- test new cloud-allowance behaviour

## Testing
- `pre-commit run --files src/tino_storm/config.py src/tino_storm/providers/llm.py tests/test_config.py tests/test_providers.py`

------
https://chatgpt.com/codex/tasks/task_e_687d2ab774b483268415d7dd9151dae1