### PR TITLE
Enable encrypted vault storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ praw
 requests
 pytesseract
 httpx<0.28
+pyyaml
+cryptography

--- a/src/tino_storm/ingest/watchdog.py
+++ b/src/tino_storm/ingest/watchdog.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from watchdog.events import FileSystemEventHandler, FileSystemEvent
 from watchdog.observers import Observer
 from datetime import datetime, timezone
+import yaml
+from cryptography.fernet import Fernet
 
 from tino_storm.loaders import load
 import json
@@ -15,6 +17,40 @@ import hashlib
 
 from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
 from llama_index.vector_stores.chroma import ChromaVectorStore
+
+
+def _load_fernet() -> Fernet | None:
+    """Return a :class:`Fernet` instance if vault encryption is enabled."""
+    cfg_path = Path("~/.tino_storm/config.yaml").expanduser()
+    if not cfg_path.exists():
+        return None
+    try:
+        cfg = yaml.safe_load(cfg_path.read_text()) or {}
+    except Exception:  # pragma: no cover - corrupt config
+        return None
+    if not cfg.get("encrypt_vault"):
+        return None
+    key = cfg.get("encryption_key")
+    if not key:
+        key = Fernet.generate_key().decode()
+        cfg["encryption_key"] = key
+        cfg_path.write_text(yaml.safe_dump(cfg))
+    return Fernet(key.encode())
+
+
+def _encrypt_dir(directory: Path, fernet: Fernet) -> None:
+    for file in directory.rglob("*"):
+        if file.is_file() and not file.name.endswith(".enc"):
+            encrypted = fernet.encrypt(file.read_bytes())
+            file.with_suffix(file.suffix + ".enc").write_bytes(encrypted)
+            file.unlink()
+
+
+def _decrypt_dir(directory: Path, fernet: Fernet) -> None:
+    for file in directory.rglob("*.enc"):
+        decrypted = fernet.decrypt(file.read_bytes())
+        file.with_suffix("").write_bytes(decrypted)
+        file.unlink()
 
 
 class IngestHandler(FileSystemEventHandler):
@@ -25,6 +61,9 @@ class IngestHandler(FileSystemEventHandler):
         self.vault_dir = Path("research") / vault
         self.storage_dir = Path("~/.tino_storm/chroma").expanduser() / vault
         self.storage_dir.mkdir(parents=True, exist_ok=True)
+        self._fernet = _load_fernet()
+        if self._fernet:
+            _decrypt_dir(self.storage_dir, self._fernet)
         vector_store = ChromaVectorStore(persist_path=str(self.storage_dir))
         self.index = VectorStoreIndex.from_vector_store(vector_store)
 
@@ -84,6 +123,8 @@ class IngestHandler(FileSystemEventHandler):
                     pass
             self.index.insert_nodes([node])
         self.index.vector_store.persist()
+        if self._fernet:
+            _encrypt_dir(self.storage_dir, self._fernet)
 
     def on_created(
         self, event: FileSystemEvent

--- a/tests/test_ingest_watchdog.py
+++ b/tests/test_ingest_watchdog.py
@@ -112,3 +112,33 @@ def test_ingest_handler_ingests(tmp_path, monkeypatch):
     handler.ingest_file(urls)
 
     assert any(handler.storage_dir.iterdir())
+
+
+def test_ingest_handler_encrypts(tmp_path, monkeypatch):
+    monkeypatch.setattr("watchdog.observers.Observer", _DummyObserver)
+    monkeypatch.chdir(tmp_path)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    cfg_dir = home / ".tino_storm"
+    cfg_dir.mkdir(parents=True)
+    from cryptography.fernet import Fernet
+
+    key = Fernet.generate_key().decode()
+    (cfg_dir / "config.yaml").write_text(
+        f"encrypt_vault: true\nencryption_key: {key}\n"
+    )
+
+    vault = "vault"
+    vault_dir = Path("research") / vault
+    vault_dir.mkdir(parents=True)
+
+    from tino_storm.ingest.watchdog import IngestHandler
+
+    handler = IngestHandler(vault)
+
+    pdf = vault_dir / "file.pdf"
+    pdf.write_text("pdf")
+    handler.ingest_file(pdf)
+
+    files = list(handler.storage_dir.iterdir())
+    assert files and all(p.suffix == ".enc" for p in files)


### PR DESCRIPTION
## Summary
- add optional encryption support for chroma vaults
- encrypt vault files when `encrypt_vault` is enabled in `~/.tino_storm/config.yaml`
- update ingestion tests and dependencies

## Testing
- `pre-commit run --files src/tino_storm/ingest/watchdog.py tests/test_ingest_watchdog.py requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687d31240728832698f166526d74ff62