### PR TITLE
Fix index persistence

### DIFF
--- a/src/tino_storm/ingest/watchdog.py
+++ b/src/tino_storm/ingest/watchdog.py
@@ -13,7 +13,6 @@ import yaml
 from cryptography.fernet import Fernet
 
 from tino_storm.loaders import load
-from tino_storm.events import ResearchAdded, save_event
 import json
 import hashlib
 
@@ -127,6 +126,7 @@ class IngestHandler(FileSystemEventHandler):
                 except Exception:
                     pass
             self.index.insert_nodes([node])
+            self.index.storage_context.persist()
         if self._fernet:
             _encrypt_dir(self.storage_dir, self._fernet)
 

--- a/tests/test_ingest_watchdog.py
+++ b/tests/test_ingest_watchdog.py
@@ -1,7 +1,6 @@
 import sys
 import types
 from pathlib import Path
-import json
 
 import pytest
 
@@ -15,10 +14,19 @@ class _FakeVectorStore:
         (self.persist_path / "index.txt").write_text("persisted")
 
 
+class _FakeStorageContext:
+    def __init__(self, store: _FakeVectorStore):
+        self.store = store
+
+    def persist(self):
+        self.store.persist()
+
+
 class _FakeIndex:
     def __init__(self, store: _FakeVectorStore | None = None):
         self.nodes = []
         self.vector_store = store or _FakeVectorStore("/tmp")
+        self.storage_context = _FakeStorageContext(self.vector_store)
 
     @classmethod
     def from_vector_store(cls, store: _FakeVectorStore) -> "_FakeIndex":
@@ -134,7 +142,7 @@ def test_ingest_handler_ingests(tmp_path, monkeypatch):
     urls.write_text("http://example.com")
     handler.ingest_file(urls)
 
-    assert any(handler.storage_dir.iterdir())
+    assert (handler.storage_dir / "index.txt").exists()
 
 
 def test_ingest_handler_encrypts(tmp_path, monkeypatch):
@@ -166,5 +174,6 @@ def test_ingest_handler_encrypts(tmp_path, monkeypatch):
     handler.ingest_file(pdf)
 
     files = list(handler.storage_dir.iterdir())
-    assert files and all(p.suffix == ".enc" for p in files)
+    assert files and (handler.storage_dir / "index.txt.enc") in files
+    assert all(p.suffix == ".enc" for p in files)
 


### PR DESCRIPTION
## Summary
- ensure VectorStoreIndex persists after ingesting nodes
- adjust tests for persisted index files

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d402e3f248326b0d17512bd51e5af