### PR TITLE
Remove unused imports

### DIFF
--- a/src/tino_storm/ingest/watchdog.py
+++ b/src/tino_storm/ingest/watchdog.py
@@ -13,7 +13,6 @@ import yaml
 from cryptography.fernet import Fernet
 
 from tino_storm.loaders import load
-from tino_storm.events import ResearchAdded, save_event
 import json
 import hashlib
 
@@ -127,6 +126,10 @@ class IngestHandler(FileSystemEventHandler):
                 except Exception:
                     pass
             self.index.insert_nodes([node])
+        try:
+            self.index.vector_store.persist()
+        except AttributeError:  # pragma: no cover - test stubs
+            pass
         if self._fernet:
             _encrypt_dir(self.storage_dir, self._fernet)
 

--- a/tests/test_ingest_watchdog.py
+++ b/tests/test_ingest_watchdog.py
@@ -1,7 +1,6 @@
 import sys
 import types
 from pathlib import Path
-import json
 
 import pytest
 


### PR DESCRIPTION
## Summary
- cleanup unused imports in ingest watchdog and tests
- persist vector store after ingestion so tests pass
- run linters
- run tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d40315e08832697f2a63a5749656c