### PR TITLE
Add optional test extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ pip install 'tino-storm[ollama]'   # Ollama backend
 pip install 'tino-storm[chroma]'   # Chroma-based ingestion
 pip install 'tino-storm[fastapi]'  # FastAPI web server
 pip install 'tino-storm[ingest]'   # File watching for ingestion
+pip install 'tino-storm[test]'     # Run the test suite
 ```
 
 Alternatively, install the latest source version from this repository to get the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,12 @@ ollama = ["ollama-python", "litellm"]
 chroma = ["chromadb", "llama-index"]
 fastapi = ["fastapi", "starlette", "httpx<0.28"]
 ingest = ["watchdog"]
+test = [
+    "pytest",
+    "httpx<0.28",
+    "pyyaml",
+    "cryptography",
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "tino_storm.__version__"}

--- a/tests/test_fastapi_app.py
+++ b/tests/test_fastapi_app.py
@@ -1,4 +1,6 @@
 import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from tino_storm import fastapi_app
@@ -77,7 +79,9 @@ def test_query_params(monkeypatch: pytest.MonkeyPatch) -> None:
         def run_pipeline(self, topic: str, ground_truth_url: str = ""):
             return _Doc("article")
 
-    def fake_create_storm(*, output_dir: str | None = None, retriever: str | None = None):
+    def fake_create_storm(
+        *, output_dir: str | None = None, retriever: str | None = None
+    ):
         calls.append((output_dir, retriever))
         return Dummy()
 

--- a/tests/test_ingest_watchdog.py
+++ b/tests/test_ingest_watchdog.py
@@ -1,9 +1,10 @@
 import sys
 import types
 from pathlib import Path
-import json
 
 import pytest
+
+pytest.importorskip("cryptography")
 
 
 class _FakeVectorStore:
@@ -151,7 +152,6 @@ def test_ingest_handler_encrypts(tmp_path, monkeypatch):
         f"encrypt_vault: true\nencryption_key: {key}\n"
     )
 
-
     vault = "vault"
     vault_dir = Path("research") / vault
     vault_dir.mkdir(parents=True)
@@ -160,11 +160,9 @@ def test_ingest_handler_encrypts(tmp_path, monkeypatch):
 
     handler = IngestHandler(vault)
 
-
     pdf = vault_dir / "file.pdf"
     pdf.write_text("pdf")
     handler.ingest_file(pdf)
 
     files = list(handler.storage_dir.iterdir())
     assert files and all(p.suffix == ".enc" for p in files)
-


### PR DESCRIPTION
## Summary
- add optional test requirements
- document optional `test` extras for test suite
- skip fastapi and cryptography dependent tests if deps missing

## Testing
- `pre-commit run --files pyproject.toml README.md tests/test_fastapi_app.py tests/test_ingest_watchdog.py`

------
https://chatgpt.com/codex/tasks/task_e_687d4030246c8326a79c56b9dbc2a53e