### PR TITLE
Enable RRF retriever composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ tino-storm polish --retriever bing --remove-duplicate
 
 The command prints the generated article. Omit ``--topic`` to be prompted interactively or pass it to run non-interactively. Use ``--help`` to see all options.
 
+To combine multiple search engines, prefix the retriever with ``rrf=`` and provide
+a comma-separated list:
+
+```bash
+tino-storm run --retriever "rrf=bing,you" --topic "Quantum computing"
+```
+
 `OPENAI_API_KEY` and `BING_SEARCH_API_KEY` must be set in the environment (or provided via ``secrets.toml``).
 
 ## Configuration
@@ -156,8 +163,8 @@ article = Storm(config).run_pipeline("Quantum computing")
 ### Environment variables
 
 The ``tino_storm.fastapi_app`` module also consults ``STORM_RETRIEVER`` to
-select the search backend. Set this variable to one of the supported providers,
-for example ``bing`` or ``serper``.
+select the search backend. Set this variable to one of the supported providers
+or use ``rrf=`` to combine them, e.g. ``STORM_RETRIEVER=rrf=bing,you``.
 
 ## Ingesting research data
 

--- a/src/tino_storm/config.py
+++ b/src/tino_storm/config.py
@@ -12,10 +12,21 @@ if TYPE_CHECKING:  # pragma: no cover - used only for type checking
 
 
 def create_retriever(name: str, k: int) -> Any:
-    """Instantiate a retriever ``name`` using environment variables."""
+    """Instantiate a retriever ``name`` using environment variables.
+
+    ``name`` can be a single provider like ``"bing"`` or a comma separated list
+    prefixed with ``"rrf="`` to compose a :class:`~tino_storm.rrf.RRFRetriever`.
+    """
     import os
 
     from .providers import get_retriever
+
+    if name.startswith("rrf="):
+        from .rrf import RRFRetriever
+
+        names = [n.strip() for n in name.split("=", 1)[1].split(",") if n.strip()]
+        retrievers = [create_retriever(n, k) for n in names]
+        return RRFRetriever(retrievers=retrievers, top_n=k)
 
     rm_cls = get_retriever(name)
     rm_kwargs = {"k": k}

--- a/tests/test_create_retriever_rrf.py
+++ b/tests/test_create_retriever_rrf.py
@@ -1,0 +1,13 @@
+from tino_storm.config import create_retriever
+from tino_storm.rrf import RRFRetriever
+
+
+def test_create_retriever_rrf(monkeypatch):
+    monkeypatch.setenv("BING_SEARCH_API_KEY", "bing")
+    monkeypatch.setenv("YDC_API_KEY", "you")
+    retriever = create_retriever("rrf=bing,you", 5)
+    assert isinstance(retriever, RRFRetriever)
+    assert len(retriever.retrievers) == 2
+    assert retriever.retrievers[0].__class__.__name__ == "BingSearch"
+    assert retriever.retrievers[1].__class__.__name__ == "YouRM"
+    assert retriever.top_n == 5


### PR DESCRIPTION
## Summary
- parse `rrf=` comma separated lists in `create_retriever`
- document RRF retriever composition in README
- test factory creation of the composed retriever

## Testing
- `pre-commit run --files README.md src/tino_storm/config.py tests/test_create_retriever_rrf.py`

------
https://chatgpt.com/codex/tasks/task_e_687d4aa596bc8326a3a07ebaa6a9ed87