### PR TITLE
Add tests for ResearchAdded events and vault decryption

### DIFF
--- a/src/tino_storm/ingest/watchdog.py
+++ b/src/tino_storm/ingest/watchdog.py
@@ -13,6 +13,7 @@ import yaml
 from cryptography.fernet import Fernet
 
 from tino_storm.loaders import load
+from tino_storm.events import ResearchAdded, save_event
 import json
 import hashlib
 

--- a/tests/test_ingest_watchdog.py
+++ b/tests/test_ingest_watchdog.py
@@ -1,6 +1,7 @@
 import sys
 import types
 from pathlib import Path
+import json
 
 import pytest
 
@@ -148,6 +149,34 @@ def test_ingest_handler_ingests(tmp_path, monkeypatch):
     assert (handler.storage_dir / "index.txt").exists()
 
 
+def test_ingest_handler_writes_event(tmp_path, monkeypatch):
+    monkeypatch.setattr("watchdog.observers.Observer", _DummyObserver)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    event_dir = tmp_path / "events"
+    monkeypatch.setenv("STORM_EVENT_DIR", str(event_dir))
+    vault = "vault"
+    vault_dir = Path("research") / vault
+    vault_dir.mkdir(parents=True)
+
+    from tino_storm.ingest.watchdog import IngestHandler
+
+    monkeypatch.setattr(
+        sys.modules["tino_storm.ingest.watchdog"], "load", lambda url: [{"text": "x"}]
+    )
+
+    handler = IngestHandler(vault)
+
+    pdf = vault_dir / "file.pdf"
+    pdf.write_text("pdf")
+    handler.ingest_file(pdf)
+
+    files = list(event_dir.iterdir())
+    assert len(files) == 1
+    data = json.loads(files[0].read_text())
+    assert data["vault"] == vault
+
+
 def test_ingest_handler_encrypts(tmp_path, monkeypatch):
     monkeypatch.setattr("watchdog.observers.Observer", _DummyObserver)
     monkeypatch.chdir(tmp_path)
@@ -177,4 +206,44 @@ def test_ingest_handler_encrypts(tmp_path, monkeypatch):
 
     files = list(handler.storage_dir.iterdir())
     assert files and all(p.suffix == ".enc" for p in files)
+
+
+def test_encrypted_vault_decrypts_on_restart(tmp_path, monkeypatch):
+    monkeypatch.setattr("watchdog.observers.Observer", _DummyObserver)
+    monkeypatch.chdir(tmp_path)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    event_dir = tmp_path / "events"
+    monkeypatch.setenv("STORM_EVENT_DIR", str(event_dir))
+    cfg_dir = home / ".tino_storm"
+    cfg_dir.mkdir(parents=True)
+    from cryptography.fernet import Fernet
+
+    key = Fernet.generate_key().decode()
+    (cfg_dir / "config.yaml").write_text(
+        f"encrypt_vault: true\nencryption_key: {key}\n"
+    )
+
+    vault = "vault"
+    vault_dir = Path("research") / vault
+    vault_dir.mkdir(parents=True)
+
+    from tino_storm.ingest.watchdog import IngestHandler
+
+    handler = IngestHandler(vault)
+
+    pdf = vault_dir / "file.pdf"
+    content = "pdf"
+    pdf.write_text(content)
+    handler.ingest_file(pdf)
+
+    files = list(handler.storage_dir.iterdir())
+    assert any(f.suffix == ".enc" for f in files)
+
+    handler = IngestHandler(vault)
+
+    files = list(handler.storage_dir.iterdir())
+    assert all(f.suffix != ".enc" for f in files)
+    decrypted = (handler.storage_dir / "index.txt").read_text()
+    assert decrypted == "persisted"
 


### PR DESCRIPTION
## Summary
- add tests validating ResearchAdded events are persisted
- test encrypted vault decrypts on restart
- import ResearchAdded and save_event in IngestHandler

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d50a8337c8326aa96ff6b2eb36185