### PR TITLE
Document HTTPX pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ pip install 'tino-storm[chroma,ingest]'
 
 You can integrate STORM into a web service using FastAPI. The repository ships with a small example app:
 
+STORM pins the `httpx` dependency to `<0.28` for compatibility. When installing the FastAPI extra this constraint
+is applied automatically:
+
 ```bash
 uvicorn examples.fastapi_example:app --reload
 ```


### PR DESCRIPTION
## Summary
- mention the pinned httpx constraint in FastAPI section

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_fastapi_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687e44223a048326b3ac867d4de94434