### PR TITLE
Add vault and citation events

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,20 @@ dependencies with:
 pip install 'tino-storm[chroma,ingest]'
 ```
 
+### Consuming events with UME
+
+STORM writes JSON events to the directory specified by `STORM_EVENT_DIR`.
+UME can monitor this folder and load the event data:
+
+```python
+import json
+from pathlib import Path
+
+for p in Path("events").glob("*.json"):
+    event = json.loads(p.read_text())
+    print(event["vault"], event["citation_hashes"])
+```
+
 
 ## Optional FastAPI mode
 

--- a/src/tino_storm/events.py
+++ b/src/tino_storm/events.py
@@ -19,12 +19,15 @@ class ResearchAdded:
     file_hash: str
     ingested_at: str
     source_url: str
+    citation_hashes: list[str]
 
 
 @dataclass
 class DocGenerated:
     topic: str
     generated_at: str
+    vault: str
+    citation_hashes: list[str]
 
 
 def save_event(event: ResearchAdded | DocGenerated, event_dir: Path | None = None) -> Path:

--- a/src/tino_storm/ingest/watchdog.py
+++ b/src/tino_storm/ingest/watchdog.py
@@ -140,6 +140,7 @@ class IngestHandler(FileSystemEventHandler):
             file_hash=file_hash,
             ingested_at=ingested_at,
             source_url=source_url,
+            citation_hashes=[file_hash],
         )
         save_event(event, self.event_dir)
 

--- a/src/tino_storm/storm.py
+++ b/src/tino_storm/storm.py
@@ -54,13 +54,20 @@ class Storm:
         ground_truth_url: str = "",
         remove_duplicate: bool = False,
         callback_handler: Optional["BaseCallbackHandler"] = None,
+        vault: str = "",
     ):
         self.build_outline(topic, ground_truth_url, callback_handler=callback_handler)
         self.generate_article(callback_handler=callback_handler)
         article = self.polish_article(remove_duplicate=remove_duplicate)
         self.runner.post_run()
+        citation_hashes = getattr(self.runner, "citation_hashes", [])
         save_event(
-            DocGenerated(topic=topic, generated_at=datetime.utcnow().isoformat()),
+            DocGenerated(
+                topic=topic,
+                generated_at=datetime.utcnow().isoformat(),
+                vault=vault,
+                citation_hashes=citation_hashes,
+            ),
             self.config.event_dir,
         )
         return article
@@ -71,7 +78,8 @@ def run_pipeline(
     topic: str,
     ground_truth_url: str = "",
     remove_duplicate: bool = False,
+    vault: str = "",
 ):
     """Run the full STORM pipeline with one function call."""
     storm = Storm(config)
-    return storm.run_pipeline(topic, ground_truth_url, remove_duplicate)
+    return storm.run_pipeline(topic, ground_truth_url, remove_duplicate, vault=vault)

--- a/tests/test_ingest_watchdog.py
+++ b/tests/test_ingest_watchdog.py
@@ -175,6 +175,7 @@ def test_ingest_handler_writes_event(tmp_path, monkeypatch):
     assert len(files) == 1
     data = json.loads(files[0].read_text())
     assert data["vault"] == vault
+    assert data["citation_hashes"] == [data["file_hash"]]
 
 
 def test_ingest_handler_encrypts(tmp_path, monkeypatch):
@@ -246,4 +247,3 @@ def test_encrypted_vault_decrypts_on_restart(tmp_path, monkeypatch):
     assert all(f.suffix != ".enc" for f in files)
     decrypted = (handler.storage_dir / "index.txt").read_text()
     assert decrypted == "persisted"
-

--- a/tests/test_storm.py
+++ b/tests/test_storm.py
@@ -40,6 +40,8 @@ def test_run_pipeline_sequence(monkeypatch):
         ("polish_article", True),
         ("post_run",),
     ]
+
+
 def test_run_pipeline_emits_event(tmp_path):
     cfg = make_config()
     cfg.event_dir = tmp_path
@@ -50,4 +52,5 @@ def test_run_pipeline_emits_event(tmp_path):
     assert len(files) == 1
     data = json.loads(files[0].read_text())
     assert data["topic"] == "topic"
-
+    assert data["vault"] == ""
+    assert "citation_hashes" in data


### PR DESCRIPTION
## Summary
- define ResearchAdded and DocGenerated formats with vault name and citation hashes
- emit citation-aware events from `Storm.run_pipeline` and ingestion watchdog
- document consuming events with UME
- update tests for new event structure

## Testing
- `pre-commit run --files src/tino_storm/events.py src/tino_storm/storm.py src/tino_storm/ingest/watchdog.py README.md tests/test_storm.py tests/test_ingest_watchdog.py`

------
https://chatgpt.com/codex/tasks/task_e_687e4a05d3d483268a0888098b16ab44