### PR TITLE
Support recency and authority ranks in RRF

### DIFF
--- a/src/knowledge_storm/rm.py
+++ b/src/knowledge_storm/rm.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime
 from typing import Callable, Union, List
 
 import backoff
@@ -8,6 +9,16 @@ import requests
 from dsp import backoff_hdlr, giveup_hdlr
 
 from .utils import WebPageHelper
+
+
+def _recency_rank(ts: str | None) -> float | None:
+    """Convert ISO timestamp ``ts`` to a sortable recency rank."""
+    if not ts:
+        return None
+    try:
+        return -datetime.fromisoformat(ts).timestamp()
+    except Exception:
+        return None
 
 
 class YouRM(dspy.Retrieve):
@@ -331,6 +342,8 @@ class VectorRM(dspy.Retrieve):
                         "snippets": [doc.page_content],
                         "title": doc.metadata["title"],
                         "url": doc.metadata["url"],
+                        "recency_rank": _recency_rank(doc.metadata.get("ingested_at")),
+                        "authority_rank": doc.metadata.get("authority_rank"),
                     }
                 )
 

--- a/src/tino_storm/ingest/watchdog.py
+++ b/src/tino_storm/ingest/watchdog.py
@@ -118,6 +118,17 @@ class IngestHandler(FileSystemEventHandler):
             "ingested_at": ingested_at,
             "source_url": source_url,
         }
+        meta_path = path.with_suffix(path.suffix + ".meta")
+        if meta_path.exists():
+            try:
+                meta_data = json.loads(meta_path.read_text())
+                if isinstance(meta_data, dict):
+                    if "authority_rank" in meta_data:
+                        metadata["authority_rank"] = meta_data["authority_rank"]
+                    elif "authority" in meta_data:
+                        metadata["authority_rank"] = meta_data["authority"]
+            except Exception:
+                pass
         for node in docs:
             if hasattr(node, "metadata") and isinstance(node.metadata, dict):
                 node.metadata.update(metadata)

--- a/tests/test_rrf_retriever.py
+++ b/tests/test_rrf_retriever.py
@@ -17,6 +17,38 @@ class DummyB:
         ]
 
 
+class DummyRecencyA:
+    def forward(self, query, exclude_urls=None):
+        return [
+            {"url": "a", "recency_rank": 1},
+            {"url": "b", "recency_rank": 0},
+        ]
+
+
+class DummyRecencyB:
+    def forward(self, query, exclude_urls=None):
+        return [
+            {"url": "b", "recency_rank": 0},
+            {"url": "a", "recency_rank": 1},
+        ]
+
+
+class DummyAuthorityA:
+    def forward(self, query, exclude_urls=None):
+        return [
+            {"url": "a", "authority_rank": 1},
+            {"url": "b", "authority_rank": 0},
+        ]
+
+
+class DummyAuthorityB:
+    def forward(self, query, exclude_urls=None):
+        return [
+            {"url": "b", "authority_rank": 0},
+            {"url": "a", "authority_rank": 1},
+        ]
+
+
 def test_rrf_ranking_order():
     retriever = RRFRetriever([DummyA(), DummyB()], k=0)
     results = retriever.forward("test")
@@ -36,3 +68,17 @@ def test_rrf_exclude_urls_iterable_equivalence():
     results_list = retriever.forward("test", exclude_urls=["b"])
     results_set = retriever.forward("test", exclude_urls={"b"})
     assert results_list == results_set
+
+
+def test_rrf_recency_rank_tiebreak():
+    retriever = RRFRetriever([DummyRecencyA(), DummyRecencyB()], k=0)
+    results = retriever.forward("test")
+    urls = [r["url"] for r in results]
+    assert urls[:2] == ["b", "a"]
+
+
+def test_rrf_authority_rank_tiebreak():
+    retriever = RRFRetriever([DummyAuthorityA(), DummyAuthorityB()], k=0)
+    results = retriever.forward("test")
+    urls = [r["url"] for r in results]
+    assert urls[:2] == ["b", "a"]


### PR DESCRIPTION
## Summary
- allow RRFRetriever to use `recency_rank` and `authority_rank`
- record optional authority metadata on ingest
- surface recency/authority info from VectorRM
- test new ranking behaviour

## Testing
- `pre-commit run --files src/tino_storm/rrf.py src/tino_storm/ingest/watchdog.py src/knowledge_storm/rm.py tests/test_rrf_retriever.py`

------
https://chatgpt.com/codex/tasks/task_e_687e4a049dc88326bc5e42e333100ace