### PR TITLE
Add tune CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Polish an existing draft:
 tino-storm polish --retriever bing --remove-duplicate
 ```
 
+Evaluate a research vault:
+
+```bash
+tino-storm tune --vault example_vault
+```
+
 The command prints the generated article. Omit ``--topic`` to be prompted interactively or pass it to run non-interactively. Use ``--help`` to see all options.
 
 To combine multiple search engines, prefix the retriever with ``rrf=`` and provide

--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -63,6 +63,14 @@ def _run_ingest(args: argparse.Namespace) -> None:
     watch_vault(args.vault)
 
 
+def _run_tune(args: argparse.Namespace) -> None:
+    from .dsp import ResearchSkill
+
+    skill = ResearchSkill()
+    accuracy = skill.tune(args.vault)
+    print(accuracy)
+
+
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
     """Register arguments shared across commands."""
 
@@ -139,6 +147,12 @@ def main(argv: list[str] | None = None) -> None:
         "--vault", required=True, help="Name of the research vault"
     )
     ingest_parser.set_defaults(func=_run_ingest)
+
+    tune_parser = sub.add_parser("tune", help="Evaluate a research vault")
+    tune_parser.add_argument(
+        "--vault", required=True, help="Name of the research vault"
+    )
+    tune_parser.set_defaults(func=_run_tune)
 
     args = parser.parse_args(argv)
     args.func(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -133,3 +133,20 @@ def test_polish_calls_polish_article(monkeypatch):
     main(["polish", "--retriever", "bing", "--remove-duplicate"])
 
     assert recorded["dup"] is True
+
+
+def test_tune_calls_research_skill(monkeypatch):
+    recorded = {}
+
+    class StubSkill:
+        def __init__(self):
+            pass
+
+        def tune(self, vault: str) -> float:
+            recorded["vault"] = vault
+            return 0.5
+
+    monkeypatch.setattr("tino_storm.dsp.ResearchSkill", StubSkill)
+    main(["tune", "--vault", "v1"])
+
+    assert recorded["vault"] == "v1"


### PR DESCRIPTION
## Summary
- extend CLI with `tune` subcommand
- call `ResearchSkill.tune()` inside CLI command
- document `tino-storm tune` in README
- test that new CLI command calls into `ResearchSkill`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e508244b08326aefcca1e22952d88