### PR TITLE
Ensure watch_vault ingests existing files

### DIFF
--- a/src/tino_storm/ingest/watchdog.py
+++ b/src/tino_storm/ingest/watchdog.py
@@ -219,6 +219,9 @@ def watch_vault(vault: str) -> None:
     watch_path = Path("research") / vault
     watch_path.mkdir(parents=True, exist_ok=True)
     handler = IngestHandler(vault)
+    for file in watch_path.iterdir():
+        if file.is_file():
+            handler.ingest_file(file)
     observer = Observer()
     observer.schedule(handler, str(watch_path), recursive=False)
     observer.start()


### PR DESCRIPTION
## Summary
- ingest any files already in the vault before starting the observer
- test that watch_vault indexes preexisting files

## Testing
- `pre-commit run --files src/tino_storm/ingest/watchdog.py tests/test_ingest_watchdog.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f95c221488326a511781d54b8ef45