### PR TITLE
Capture citation hashes for each ingested node

### DIFF
--- a/tests/test_ingest_watchdog.py
+++ b/tests/test_ingest_watchdog.py
@@ -3,6 +3,7 @@ import types
 from pathlib import Path
 import json
 import yaml
+import hashlib
 
 import pytest
 
@@ -176,7 +177,8 @@ def test_ingest_handler_writes_event(tmp_path, monkeypatch):
     assert len(files) == 1
     data = json.loads(files[0].read_text())
     assert data["vault"] == vault
-    assert data["citation_hashes"] == [data["file_hash"]]
+    expected_hash = hashlib.sha1("doc:file.pdf".encode()).hexdigest()
+    assert data["citation_hashes"] == [expected_hash]
 
 
 def test_ingest_handler_encrypts(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- compute a unique hash for every ingested node and store in metadata
- include all node hashes in `ResearchAdded.citation_hashes`
- adjust the event test to expect the new citation hashes

## Testing
- `pre-commit run --files src/tino_storm/ingest/watchdog.py tests/test_ingest_watchdog.py`

------
https://chatgpt.com/codex/tasks/task_e_687f95c3d4dc83268c26aa7b9b7837e9