### PR TITLE
Add pytest-cov and enforce coverage

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,11 +21,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install '.[fastapi]'
+          pip install '.[fastapi,test]'
       - name: Run Ruff
         run: |
           pip install ruff
           ruff check src/knowledge_storm src/tino_storm tests
       - name: Run tests
         run: |
-          PYTHONPATH=. pytest
+          PYTHONPATH=. pytest --cov=src --cov-report=xml --cov-fail-under=8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ test = [
     "httpx<0.28",
     "pyyaml",
     "cryptography",
+    "pytest-cov",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## Summary
- include `pytest-cov` in the test extras
- run tests with coverage in CI and fail if coverage is <8%

## Testing
- `ruff check src/knowledge_storm src/tino_storm tests`
- `pytest --cov=src --cov-report=term --cov-fail-under=8`

------
https://chatgpt.com/codex/tasks/task_e_687f9ca828888326a2fa9238759c52ec