### PR TITLE
Add plan-project CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Generate the outline only:
 tino-storm outline --retriever bing --topic "Quantum computing"
 ```
 
+Create a project plan in Markdown:
+
+```bash
+tino-storm plan-project --retriever bing --topic "Quantum computing"
+```
+
 Draft the article from a saved outline:
 
 ```bash

--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -43,6 +43,21 @@ def _run_outline(args: argparse.Namespace) -> None:
     print(outline)
 
 
+def _run_plan_project(args: argparse.Namespace) -> None:
+    """Generate a markdown outline for ``args.topic``."""
+    config = make_config(args)
+    storm = Storm(config)
+    topic = args.topic or input("Topic: ")
+    outline = storm.build_outline(topic)
+    try:
+        items = outline.get_outline_as_list(add_hashtags=True, include_root=False)
+    except AttributeError:
+        text = str(outline)
+        items = [line for line in text.splitlines() if line.strip()]
+    md = "\n".join(f"- {item}" for item in items)
+    print(md)
+
+
 def _run_draft(args: argparse.Namespace) -> None:
     config = make_config(args)
     storm = Storm(config)
@@ -130,6 +145,19 @@ def main(argv: list[str] | None = None) -> None:
         help="Topic to research. Prompted if omitted",
     )
     outline_parser.set_defaults(func=_run_outline)
+
+    plan_parser = sub.add_parser(
+        "plan-project", help="Generate a project plan outline in Markdown"
+    )
+    _add_common_args(plan_parser)
+    plan_parser.add_argument(
+        "--topic",
+        "-t",
+        type=str,
+        default=None,
+        help="Topic to research. Prompted if omitted",
+    )
+    plan_parser.set_defaults(func=_run_plan_project)
 
     draft_parser = sub.add_parser("draft", help="Generate an article draft")
     _add_common_args(draft_parser)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,7 +82,9 @@ def test_outline_uses_topic_arg(monkeypatch):
     _setup_env(monkeypatch)
     recorded = {}
 
-    def build_outline(self, topic: str, ground_truth_url: str = "", callback_handler=None):
+    def build_outline(
+        self, topic: str, ground_truth_url: str = "", callback_handler=None
+    ):
         recorded["topic"] = topic
         return "outline"
 
@@ -96,13 +98,48 @@ def test_outline_prompts_for_topic(monkeypatch):
     _setup_env(monkeypatch)
     recorded = {}
 
-    def build_outline(self, topic: str, ground_truth_url: str = "", callback_handler=None):
+    def build_outline(
+        self, topic: str, ground_truth_url: str = "", callback_handler=None
+    ):
         recorded["topic"] = topic
         return "outline"
 
     monkeypatch.setattr(Storm, "build_outline", build_outline)
     monkeypatch.setattr("builtins.input", lambda _: "dogs")
     main(["outline", "--retriever", "bing"])
+
+    assert recorded["topic"] == "dogs"
+
+
+def test_plan_project_uses_topic_arg(monkeypatch):
+    _setup_env(monkeypatch)
+    recorded = {}
+
+    def build_outline(
+        self, topic: str, ground_truth_url: str = "", callback_handler=None
+    ):
+        recorded["topic"] = topic
+        return "outline"
+
+    monkeypatch.setattr(Storm, "build_outline", build_outline)
+    main(["plan-project", "--retriever", "bing", "--topic", "cats"])
+
+    assert recorded["topic"] == "cats"
+
+
+def test_plan_project_prompts_for_topic(monkeypatch):
+    _setup_env(monkeypatch)
+    recorded = {}
+
+    def build_outline(
+        self, topic: str, ground_truth_url: str = "", callback_handler=None
+    ):
+        recorded["topic"] = topic
+        return "outline"
+
+    monkeypatch.setattr(Storm, "build_outline", build_outline)
+    monkeypatch.setattr("builtins.input", lambda _: "dogs")
+    main(["plan-project", "--retriever", "bing"])
 
     assert recorded["topic"] == "dogs"
 


### PR DESCRIPTION
## Summary
- extend `cli` with `plan-project` subcommand
- format outline as Markdown bullet list
- document new subcommand
- test new behavior

## Testing
- `pre-commit run --files README.md src/tino_storm/cli.py tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_687f9ca5f01c8326ae21def955d0dc55