### PR TITLE
Make ResearchSkill tune directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ article = skill("Deep learning", table)
 ### Tuning
 
 Each research vault can include a small `eval.jsonl` file with evaluation topics. The
-`ResearchSkill.tune()` method loads this data and evaluates the skill. This can be
-used with simple stub LMs for local experiments:
+`ResearchSkill.tune()` method loads this data and evaluates the skill. Vaults are
+searched relative to ``STORM_RESEARCH_DIR`` (defaults to ``./research``) or a custom
+``base_dir`` passed to ``tune()``. This can be used with simple stub LMs for local
+experiments:
 
 ```python
 accuracy = skill.tune("example_vault")
@@ -193,6 +195,10 @@ or use ``rrf=`` to combine them, e.g. ``STORM_RETRIEVER=rrf=bing,you``.
 
 Set ``STORM_CLOUD_ALLOWED=false`` to disable cloud-based LLM providers and
 restrict the pipeline to local models like Ollama.
+Set ``STORM_RESEARCH_DIR`` to point to the directory containing research vaults
+(defaults to ``./research``). ``ResearchSkill.tune()`` will look for
+``eval.jsonl`` in ``$STORM_RESEARCH_DIR/<vault>`` unless you pass a different
+``base_dir`` argument.
 
 ## Ingesting research data
 

--- a/src/tino_storm/dsp/skill.py
+++ b/src/tino_storm/dsp/skill.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Optional, Dict
 
@@ -59,9 +60,23 @@ class ResearchSkill:
         )
         return article == sample.get("expected")
 
-    def tune(self, vault: str) -> float:
-        """Refine submodules using DSPy and return the resulting accuracy."""
-        path = Path(__file__).resolve().parents[3] / "research" / vault / "eval.jsonl"
+    def tune(self, vault: str, *, base_dir: Optional[str | Path] = None) -> float:
+        """Refine submodules using DSPy and return the resulting accuracy.
+
+        Parameters
+        ----------
+        vault:
+            Name of the research vault containing ``eval.jsonl``.
+        base_dir:
+            Base directory where vaults are stored. If omitted, the value of
+            ``STORM_RESEARCH_DIR`` is used. Defaults to ``./research`` when the
+            environment variable is not set.
+        """
+
+        if base_dir is None:
+            base_dir = os.getenv("STORM_RESEARCH_DIR", "research")
+
+        path = Path(base_dir) / vault / "eval.jsonl"
         if not path.exists():
             raise FileNotFoundError(f"Eval set not found: {path}")
 


### PR DESCRIPTION
## Summary
- let `ResearchSkill.tune` read evaluation data from `base_dir` or `STORM_RESEARCH_DIR`
- document how to configure research vault location

## Testing
- `ruff check src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb3d110d88326ad01ba1437a6afb2