### PR TITLE
Make CLI retriever flag optional

### DIFF
--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -22,7 +22,8 @@ def make_config(args: argparse.Namespace | None = None) -> StormConfig:
     config.args.max_thread_num = args.max_thread_num
     config.args.retrieve_top_k = args.retrieve_top_k
 
-    config.rm = create_retriever(args.retriever, config.args.search_top_k)
+    if args.retriever is not None:
+        config.rm = create_retriever(args.retriever, config.args.search_top_k)
 
     return config
 
@@ -98,7 +99,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--retriever",
         type=str,
-        required=True,
+        default=None,
         choices=[
             "bing",
             "you",
@@ -109,7 +110,7 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
             "searxng",
             "azure_ai_search",
         ],
-        help="Search engine to use",
+        help="Search engine to use (defaults to STORM_RETRIEVER)",
     )
     parser.add_argument("--max-conv-turn", type=int, default=3)
     parser.add_argument("--max-perspective", type=int, default=3)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,6 +158,29 @@ def test_draft_calls_generate_article(monkeypatch):
     assert called.get("called")
 
 
+def test_cli_uses_env_retriever_when_flag_absent(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("STORM_RETRIEVER", "arxiv")
+
+    recorded = {}
+
+    def fake_create_retriever(name: str, k: int):
+        recorded["name"] = name
+
+        class Dummy:
+            pass
+
+        return Dummy()
+
+    monkeypatch.setattr("tino_storm.config.create_retriever", fake_create_retriever)
+    monkeypatch.setattr("tino_storm.cli.create_retriever", fake_create_retriever)
+    monkeypatch.setattr(Storm, "run_pipeline", lambda *args, **kwargs: "article")
+
+    main(["run", "--topic", "cats"])
+
+    assert recorded["name"] == "arxiv"
+
+
 def test_polish_calls_polish_article(monkeypatch):
     _setup_env(monkeypatch)
     recorded = {}


### PR DESCRIPTION
## Summary
- respect `STORM_RETRIEVER` env var when CLI `--retriever` is missing
- adjust help text for `--retriever`
- test CLI behavior with `STORM_RETRIEVER`

## Testing
- `pre-commit run --files src/tino_storm/cli.py tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_687fb3d1d5b083268993efb680743d0f