### PR TITLE
Add CLI and API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,22 @@ python examples/costorm_examples/run_costorm_gpt.py \
     --retriever bing
 ```
 
+### CLI
+
+Install the package and use the ``tino-storm`` command to run a basic research
+task or launch the API server.
+
+```bash
+# Run a research task and store results under ./results
+tino-storm research "Quantum computing" --output-dir ./results
+
+# Launch the FastAPI service
+tino-storm serve --host 0.0.0.0 --port 8000
+```
+
+Once the server is running you can send a ``POST`` request to ``/research`` with
+``{"topic": "Your topic"}`` to trigger a run.
+
 
 ## Customization of the Pipeline
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tino-storm"
+version = "0.1.0"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+tino-storm = "tino_storm.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src", ""]
+include = ["tino_storm*", "knowledge_storm*"]

--- a/src/tino_storm/__init__.py
+++ b/src/tino_storm/__init__.py
@@ -1,0 +1,3 @@
+"""Utilities for running STORM from the command line or via API."""
+
+__all__ = ["cli", "api"]

--- a/src/tino_storm/api.py
+++ b/src/tino_storm/api.py
@@ -1,0 +1,64 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Optional
+
+from knowledge_storm import (
+    STORMWikiRunnerArguments,
+    STORMWikiRunner,
+    STORMWikiLMConfigs,
+)
+from knowledge_storm.lm import LitellmModel
+from knowledge_storm.rm import BingSearch
+
+
+class ResearchRequest(BaseModel):
+    topic: str
+    output_dir: Optional[str] = "./results"
+
+
+app = FastAPI(title="Tino STORM API")
+
+
+def _make_default_runner(output_dir: str) -> STORMWikiRunner:
+    lm_configs = STORMWikiLMConfigs()
+    openai_kwargs = {
+        "api_key": None,
+        "temperature": 1.0,
+        "top_p": 0.9,
+    }
+    gpt_35 = LitellmModel(model="gpt-3.5-turbo", max_tokens=500, **openai_kwargs)
+    gpt_4 = LitellmModel(model="gpt-4o", max_tokens=3000, **openai_kwargs)
+    lm_configs.set_conv_simulator_lm(gpt_35)
+    lm_configs.set_question_asker_lm(gpt_35)
+    lm_configs.set_outline_gen_lm(gpt_4)
+    lm_configs.set_article_gen_lm(gpt_4)
+    lm_configs.set_article_polish_lm(gpt_4)
+
+    args = STORMWikiRunnerArguments(output_dir=output_dir)
+    rm = BingSearch(k=args.search_top_k)
+    return STORMWikiRunner(args, lm_configs, rm)
+
+
+def run_research(
+    topic: str,
+    output_dir: str = "./results",
+    do_research: bool = True,
+    do_generate_outline: bool = True,
+    do_generate_article: bool = True,
+    do_polish_article: bool = True,
+) -> None:
+    runner = _make_default_runner(output_dir)
+    runner.run(
+        topic=topic,
+        do_research=do_research,
+        do_generate_outline=do_generate_outline,
+        do_generate_article=do_generate_article,
+        do_polish_article=do_polish_article,
+    )
+    runner.post_run()
+
+
+@app.post("/research")
+def research(req: ResearchRequest):
+    run_research(topic=req.topic, output_dir=req.output_dir)
+    return {"status": "ok"}

--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -1,0 +1,50 @@
+import argparse
+import os
+import uvicorn
+
+from .api import app, run_research
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Run STORM research pipelines")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    research_p = subparsers.add_parser("research", help="Run a single research task")
+    research_p.add_argument("topic", help="Topic to research")
+    research_p.add_argument(
+        "--output-dir", default="./results", help="Directory for generated files"
+    )
+    research_p.add_argument(
+        "--skip-research", action="store_true", help="Skip information retrieval"
+    )
+    research_p.add_argument(
+        "--skip-outline", action="store_true", help="Skip outline generation"
+    )
+    research_p.add_argument(
+        "--skip-article", action="store_true", help="Skip article generation"
+    )
+    research_p.add_argument(
+        "--skip-polish", action="store_true", help="Skip article polishing"
+    )
+
+    serve_p = subparsers.add_parser("serve", help="Launch API server")
+    serve_p.add_argument("--host", default="0.0.0.0")
+    serve_p.add_argument("--port", type=int, default=8000)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "research":
+        run_research(
+            topic=args.topic,
+            output_dir=args.output_dir,
+            do_research=not args.skip_research,
+            do_generate_outline=not args.skip_outline,
+            do_generate_article=not args.skip_article,
+            do_polish_article=not args.skip_polish,
+        )
+    elif args.command == "serve":
+        uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add FastAPI API and CLI interface in new `tino_storm` package
- expose `tino-storm` console script via `pyproject.toml`
- update README with usage examples for CLI and server
- include basic package `__init__`

## Testing
- `pre-commit run --files README.md pyproject.toml src/tino_storm/cli.py src/tino_storm/api.py src/tino_storm/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688049eddc1c832697c0bf0826ed1c2b