### PR TITLE
Add chroma vault watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ You could also install the source code which allows you to modify the behavior o
    conda activate storm
    pip install -r requirements.txt
    ```
+
+## Vault ingestion
+
+STORM can automatically ingest documents dropped under a vault directory. Set `STORM_VAULT_ROOT`
+to the folder containing your research vaults (defaults to `research`). Each subfolder is treated
+as a vault and mapped to a Chroma collection with the same name. Collections are stored under
+`STORM_CHROMA_PATH` which defaults to `~/.tino_storm/chroma/`.
+
+Start the watcher from Python:
+
+```python
+from tino_storm.ingest import start_watcher
+
+start_watcher()  # watches STORM_VAULT_ROOT for new files or URL lists
+```
    
 
 ## API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "langchain-qdrant",
     "numpy==1.26.4",
     "litellm==1.59.3",
+    "watchdog",
+    "chromadb",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,6 @@ qdrant-client
 langchain-qdrant
 numpy==1.26.4
 litellm==1.59.3
+watchdog
+chromadb
 diskcache

--- a/src/tino_storm/ingest/__init__.py
+++ b/src/tino_storm/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for ingesting external resources into Chroma collections."""
+
+from .watcher import start_watcher, VaultIngestHandler
+
+__all__ = ["start_watcher", "VaultIngestHandler"]

--- a/src/tino_storm/ingest/watcher.py
+++ b/src/tino_storm/ingest/watcher.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+import chromadb
+import trafilatura
+
+
+class VaultIngestHandler(FileSystemEventHandler):
+    """Watch a vault directory and ingest dropped files or URLs."""
+
+    def __init__(self, root: str, chroma_path: Optional[str] = None) -> None:
+        self.root = Path(root).expanduser().resolve()
+        chroma_root = Path(
+            chroma_path
+            or os.environ.get(
+                "STORM_CHROMA_PATH", Path.home() / ".tino_storm" / "chroma"
+            )
+        ).expanduser()
+        chroma_root.mkdir(parents=True, exist_ok=True)
+        self.client = chromadb.PersistentClient(path=str(chroma_root))
+        super().__init__()
+
+    def _ingest_text(self, text: str, source: str, vault: str) -> None:
+        collection = self.client.get_or_create_collection(vault)
+        # Use timestamp to provide unique ids
+        doc_id = f"{source}-{int(time.time()*1000)}"
+        collection.add(documents=[text], metadatas=[{"source": source}], ids=[doc_id])
+
+    def _handle_file(self, path: Path, vault: str) -> None:
+        if path.suffix.lower() in {".url", ".urls"}:
+            lines = [l.strip() for l in path.read_text().splitlines() if l.strip()]
+            for url in lines:
+                html = trafilatura.fetch_url(url)
+                text = trafilatura.extract(html) or ""
+                if text:
+                    self._ingest_text(text, url, vault)
+        else:
+            try:
+                text = path.read_text(encoding="utf-8")
+            except Exception:
+                return
+            self._ingest_text(text, str(path), vault)
+
+    def on_created(self, event) -> None:  # pragma: no cover - side effects
+        if event.is_directory:
+            return
+        path = Path(event.src_path)
+        try:
+            rel = path.relative_to(self.root)
+        except ValueError:
+            return
+        vault = rel.parts[0]
+        self._handle_file(path, vault)
+
+
+def start_watcher(
+    root: Optional[str] = None, chroma_path: Optional[str] = None
+) -> None:
+    """Start watching ``root`` for dropped files/URLs."""
+
+    watch_root = Path(
+        root or os.environ.get("STORM_VAULT_ROOT", "research")
+    ).expanduser()
+    handler = VaultIngestHandler(str(watch_root), chroma_path=chroma_path)
+    observer = Observer()
+    observer.schedule(handler, str(watch_root), recursive=True)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:  # pragma: no cover - manual termination
+        observer.stop()
+    observer.join()


### PR DESCRIPTION
## Summary
- watch research folders for new files or URLs
- ingest new data into Chroma collections located in `~/.tino_storm/chroma`
- document watcher usage and environment variables
- include `watchdog` and `chromadb` dependencies

## Testing
- `black src/tino_storm/ingest >/tmp/black.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68805007797c8326869570391d25acdb