### PR TITLE
Add social media loaders with OCR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ dependencies = [
     "langchain-qdrant",
     "numpy==1.26.4",
     "litellm==1.59.3",
+    "snscrape",
+    "praw",
+    "pytesseract",
+    "pillow",
+    "pytz",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,9 @@ qdrant-client
 langchain-qdrant
 numpy==1.26.4
 litellm==1.59.3
+snscrape
+praw
+pytesseract
+pillow
 diskcache
+pytz

--- a/src/tino_storm/__init__.py
+++ b/src/tino_storm/__init__.py
@@ -41,4 +41,3 @@ def __getattr__(name: str):
         globals()[name] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-

--- a/src/tino_storm/ingestion/__init__.py
+++ b/src/tino_storm/ingestion/__init__.py
@@ -1,0 +1,6 @@
+from .twitter import TwitterScraper
+from .reddit import RedditScraper
+from .fourchan import FourChanScraper
+from .utils import ocr_image
+
+__all__ = ["TwitterScraper", "RedditScraper", "FourChanScraper", "ocr_image"]

--- a/src/tino_storm/ingestion/fourchan.py
+++ b/src/tino_storm/ingestion/fourchan.py
@@ -1,0 +1,40 @@
+import json
+from datetime import datetime
+from typing import List
+
+import requests
+
+from .utils import ocr_image
+
+
+class FourChanScraper:
+    """Scrape threads from 4chan's JSON API."""
+
+    API_URL = "https://a.4cdn.org/{board}/thread/{thread}.json"
+
+    def fetch_thread(self, board: str, thread_no: int) -> List[dict]:
+        url = self.API_URL.format(board=board, thread=thread_no)
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        posts = []
+        for p in data.get("posts", []):
+            images_text = []
+            if "tim" in p and "ext" in p:
+                img_url = f"https://i.4cdn.org/{board}/{p['tim']}{p['ext']}"
+                text = ocr_image(img_url)
+                if text:
+                    images_text.append(text)
+            posts.append(
+                {
+                    "id": p.get("no"),
+                    "date": datetime.utcfromtimestamp(p.get("time", 0)).isoformat(),
+                    "author": p.get("name"),
+                    "text": p.get("com"),
+                    "images_text": images_text,
+                }
+            )
+        return posts
+
+    def dump_json(self, board: str, thread_no: int) -> str:
+        return json.dumps(self.fetch_thread(board, thread_no))

--- a/src/tino_storm/ingestion/reddit.py
+++ b/src/tino_storm/ingestion/reddit.py
@@ -1,0 +1,82 @@
+import json
+from datetime import datetime
+from typing import List, Optional
+
+import praw
+import requests
+
+from .utils import ocr_image
+
+
+class RedditScraper:
+    """Fetch posts from Reddit using praw with Pushshift fallback."""
+
+    def __init__(
+        self,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        user_agent: str = "storm",
+    ) -> None:
+        try:
+            self.reddit = praw.Reddit(
+                client_id=client_id, client_secret=client_secret, user_agent=user_agent
+            )
+        except Exception:
+            self.reddit = None
+
+    def _post_to_dict(self, post) -> dict:
+        images_text = []
+        if post.url and post.url.lower().endswith((".png", ".jpg", ".jpeg", ".gif")):
+            text = ocr_image(post.url)
+            if text:
+                images_text.append(text)
+        return {
+            "id": post.id,
+            "date": datetime.utcfromtimestamp(post.created_utc).isoformat(),
+            "author": getattr(post.author, "name", None),
+            "title": post.title,
+            "text": getattr(post, "selftext", ""),
+            "url": post.url,
+            "images_text": images_text,
+        }
+
+    def _pushshift_search(self, subreddit: str, query: str, limit: int) -> List[dict]:
+        url = "https://api.pushshift.io/reddit/search/submission"
+        params = {"subreddit": subreddit, "q": query, "size": limit}
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+        results = []
+        for item in data:
+            images_text = []
+            if item.get("url", "").lower().endswith((".png", ".jpg", ".jpeg", ".gif")):
+                text = ocr_image(item["url"])
+                if text:
+                    images_text.append(text)
+            results.append(
+                {
+                    "id": item.get("id"),
+                    "date": datetime.utcfromtimestamp(
+                        item.get("created_utc", 0)
+                    ).isoformat(),
+                    "author": item.get("author"),
+                    "title": item.get("title"),
+                    "text": item.get("selftext", ""),
+                    "url": item.get("url"),
+                    "images_text": images_text,
+                }
+            )
+        return results
+
+    def search(self, subreddit: str, query: str, limit: int = 20) -> List[dict]:
+        if self.reddit is not None:
+            try:
+                sub = self.reddit.subreddit(subreddit)
+                posts = sub.search(query, limit=limit)
+                return [self._post_to_dict(p) for p in posts]
+            except Exception:
+                pass
+        return self._pushshift_search(subreddit, query, limit)
+
+    def dump_json(self, subreddit: str, query: str, limit: int = 20) -> str:
+        return json.dumps(self.search(subreddit, query, limit))

--- a/src/tino_storm/ingestion/twitter.py
+++ b/src/tino_storm/ingestion/twitter.py
@@ -1,0 +1,40 @@
+import json
+from typing import List
+import snscrape.modules.twitter as sntwitter
+
+from .utils import ocr_image
+
+
+class TwitterScraper:
+    """Search tweets using snscrape and return a list of dictionaries."""
+
+    def search(self, query: str, limit: int = 20) -> List[dict]:
+        scraper = sntwitter.TwitterSearchScraper(query)
+        results = []
+        for i, tweet in enumerate(scraper.get_items()):
+            if i >= limit:
+                break
+            images_text = []
+            media = getattr(tweet, "media", None)
+            if media:
+                for m in media:
+                    if getattr(m, "type", None) == "photo" and getattr(
+                        m, "fullUrl", None
+                    ):
+                        text = ocr_image(m.fullUrl)
+                        if text:
+                            images_text.append(text)
+            results.append(
+                {
+                    "id": tweet.id,
+                    "date": tweet.date.isoformat(),
+                    "author": tweet.user.username,
+                    "text": tweet.rawContent,
+                    "url": tweet.url,
+                    "images_text": images_text,
+                }
+            )
+        return results
+
+    def dump_json(self, query: str, limit: int = 20) -> str:
+        return json.dumps(self.search(query, limit))

--- a/src/tino_storm/ingestion/utils.py
+++ b/src/tino_storm/ingestion/utils.py
@@ -1,0 +1,16 @@
+import httpx
+from io import BytesIO
+from PIL import Image
+import pytesseract
+
+
+def ocr_image(url: str) -> str:
+    """Download an image from ``url`` and return extracted text using pytesseract."""
+    try:
+        resp = httpx.get(url, timeout=10)
+        resp.raise_for_status()
+        image = Image.open(BytesIO(resp.content))
+        text = pytesseract.image_to_string(image)
+        return text.strip()
+    except Exception:
+        return ""

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,111 @@
+import datetime
+from unittest.mock import patch
+
+import types
+
+import pytest
+
+ROOT_DIR = None
+import os
+import sys
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+SRC_DIR = os.path.join(ROOT_DIR, "src")
+if os.path.isdir(SRC_DIR) and SRC_DIR not in sys.path:
+    sys.path.insert(0, SRC_DIR)
+
+# Stub external modules so importing ingestion does not require heavy deps
+sys.modules.setdefault("snscrape", types.ModuleType("snscrape"))
+sys.modules.setdefault("snscrape.modules", types.ModuleType("snscrape.modules"))
+twitter_mod = types.ModuleType("snscrape.modules.twitter")
+twitter_mod.TwitterSearchScraper = object
+sys.modules.setdefault("snscrape.modules.twitter", twitter_mod)
+
+from tino_storm.ingestion import TwitterScraper, RedditScraper, FourChanScraper
+
+
+class DummyTweet:
+    def __init__(self):
+        self.id = 1
+        self.date = datetime.datetime(2021, 1, 1, 0, 0, 0)
+        self.user = type("U", (), {"username": "tester"})
+        self.rawContent = "text"
+        self.url = "http://t.co/1"
+        self.media = [type("M", (), {"type": "photo", "fullUrl": "http://img"})]
+
+
+def test_twitter_scraper():
+    with patch("snscrape.modules.twitter.TwitterSearchScraper") as Scraper:
+        Scraper.return_value.get_items.return_value = [DummyTweet()]
+        with patch("tino_storm.ingestion.twitter.ocr_image", return_value="ocr"):
+            scraper = TwitterScraper()
+            data = scraper.search("test", limit=1)
+            assert data[0]["author"] == "tester"
+            assert data[0]["images_text"] == ["ocr"]
+
+
+class DummyRedditPost:
+    id = "abc"
+    created_utc = 1609459200
+    author = type("A", (), {"name": "redditor"})
+    title = "title"
+    selftext = "body"
+    url = "http://img.png"
+
+
+def test_reddit_scraper_praw():
+    with patch("praw.Reddit") as Reddit:
+        Reddit.return_value.subreddit.return_value.search.return_value = [
+            DummyRedditPost
+        ]
+        with patch("tino_storm.ingestion.reddit.ocr_image", return_value="ocr"):
+            scraper = RedditScraper(client_id="a", client_secret="b")
+            data = scraper.search("sub", "q", limit=1)
+            assert data[0]["title"] == "title"
+            assert data[0]["images_text"] == ["ocr"]
+
+
+def test_reddit_scraper_pushshift():
+    with patch("praw.Reddit", side_effect=Exception):
+        with patch("requests.get") as g:
+            g.return_value.status_code = 200
+            g.return_value.json.return_value = {
+                "data": [
+                    {
+                        "id": "def",
+                        "created_utc": 1609459200,
+                        "author": "user",
+                        "title": "t",
+                        "selftext": "b",
+                        "url": "http://img.png",
+                    }
+                ]
+            }
+            with patch("tino_storm.ingestion.reddit.ocr_image", return_value="ocr"):
+                scraper = RedditScraper(client_id="a", client_secret="b")
+                data = scraper.search("sub", "q", limit=1)
+                assert data[0]["id"] == "def"
+
+
+def test_fourchan_scraper():
+    with patch("requests.get") as g:
+        g.return_value.status_code = 200
+        g.return_value.json.return_value = {
+            "posts": [
+                {
+                    "no": 123,
+                    "time": 1609459200,
+                    "name": "anon",
+                    "com": "hello",
+                    "tim": "abc",
+                    "ext": ".jpg",
+                }
+            ]
+        }
+        with patch("tino_storm.ingestion.fourchan.ocr_image", return_value="ocr"):
+            scraper = FourChanScraper()
+            data = scraper.fetch_thread("g", 1)
+            assert data[0]["author"] == "anon"
+            assert data[0]["images_text"] == ["ocr"]


### PR DESCRIPTION
## Summary
- implement `ingestion` package with loaders for Twitter, Reddit and 4chan
- include OCR helper using pytesseract
- expose new loaders in package init
- add unit tests with mocked APIs
- update dependencies

## Testing
- `pre-commit run --files tests/test_ingestion.py src/tino_storm/ingestion/twitter.py src/tino_storm/ingestion/reddit.py src/tino_storm/ingestion/fourchan.py src/tino_storm/ingestion/utils.py src/tino_storm/ingestion/__init__.py pyproject.toml requirements.txt src/tino_storm/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68805003f190832680e54a4c161faab2