### PR TITLE
Add RRF ranking and archive superseded chunks

### DIFF
--- a/src/tino_storm/retrieval/__init__.py
+++ b/src/tino_storm/retrieval/__init__.py
@@ -1,0 +1,19 @@
+"""Utilities for advanced retrieval ranking."""
+
+from .rrf import reciprocal_rank_fusion
+from typing import List, Dict, Any
+
+
+def combine_ranks(
+    recency_ranking: List[Dict[str, Any]],
+    authority_ranking: List[Dict[str, Any]],
+    similarity_ranking: List[Dict[str, Any]],
+    k: int = 60,
+) -> List[Dict[str, Any]]:
+    """Fuse results from three ranking strategies using RRF."""
+    return reciprocal_rank_fusion(
+        [recency_ranking, authority_ranking, similarity_ranking], k=k
+    )
+
+
+__all__ = ["reciprocal_rank_fusion", "combine_ranks"]

--- a/src/tino_storm/retrieval/rrf.py
+++ b/src/tino_storm/retrieval/rrf.py
@@ -1,0 +1,30 @@
+from collections import defaultdict
+from typing import List, Dict, Any
+
+
+def reciprocal_rank_fusion(
+    rankings: List[List[Dict[str, Any]]], k: int = 60
+) -> List[Dict[str, Any]]:
+    """Combine multiple ranking lists using Reciprocal Rank Fusion (RRF).
+
+    Each element in ``rankings`` should be a list of dictionaries representing
+    retrieval results ordered from best to worst. Dictionaries must contain a
+    unique identifier accessible via the ``url`` key. The final ranking is
+    computed using ``1 / (k + rank)`` for each list and aggregated per url.
+    ``k`` controls how steeply scores decay with rank.
+    """
+
+    scores: Dict[str, float] = defaultdict(float)
+    info_by_url: Dict[str, Dict[str, Any]] = {}
+
+    for results in rankings:
+        for rank, info in enumerate(results, start=1):
+            url = info.get("url")
+            if url is None:
+                continue
+            scores[url] += 1.0 / (k + rank)
+            if url not in info_by_url:
+                info_by_url[url] = info
+
+    ordered_urls = sorted(scores, key=scores.get, reverse=True)
+    return [info_by_url[url] for url in ordered_urls]

--- a/src/tino_storm/utils.py
+++ b/src/tino_storm/utils.py
@@ -248,17 +248,17 @@ class QdrantVectorStoreManager:
         if url_column not in df.columns:
             raise ValueError(f"URL column {url_column} not found in the csv file.")
 
-        documents = [
-            Document(
-                page_content=row[content_column],
-                metadata={
-                    "title": row.get(title_column, ""),
-                    "url": row[url_column],
-                    "description": row.get(desc_column, ""),
-                },
+        documents = []
+        for row in df.to_dict(orient="records"):
+            metadata = {
+                "title": row.get(title_column, ""),
+                "url": row[url_column],
+                "description": row.get(desc_column, ""),
+                "status": "active",
+            }
+            documents.append(
+                Document(page_content=row[content_column], metadata=metadata)
             )
-            for row in df.to_dict(orient="records")
-        ]
 
         # split the documents
         from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -278,11 +278,38 @@ class QdrantVectorStoreManager:
                 "\uff0c",  # Fullwidth comma
                 "\u3001",  # Ideographic comma
                 " ",
-                "\u200B",  # Zero-width space
+                "\u200b",  # Zero-width space
                 "",
             ],
         )
         split_documents = text_splitter.split_documents(documents)
+
+        from qdrant_client.http import models as qdrant_models
+
+        # Mark superseded chunks as archived if they already exist
+        for doc in split_documents:
+            url = doc.metadata.get("url")
+            if not url:
+                continue
+            existing, _ = qdrant.client.scroll(
+                collection_name=collection_name,
+                scroll_filter=qdrant_models.Filter(
+                    must=[
+                        qdrant_models.FieldCondition(
+                            key="url",
+                            match=qdrant_models.MatchValue(value=url),
+                        )
+                    ]
+                ),
+                with_payload=True,
+            )
+            point_ids = [rec.id for rec in existing]
+            if point_ids:
+                qdrant.client.set_payload(
+                    collection_name=collection_name,
+                    payload={"status": "archived"},
+                    points=point_ids,
+                )
 
         # update and save the vector store
         num_batches = (len(split_documents) + batch_size - 1) // batch_size
@@ -666,7 +693,7 @@ class WebPageHelper:
                 "\uff0c",  # Fullwidth comma
                 "\u3001",  # Ideographic comma
                 " ",
-                "\u200B",  # Zero-width space
+                "\u200b",  # Zero-width space
                 "",
             ],
         )


### PR DESCRIPTION
## Summary
- implement reciprocal rank fusion in `src/tino_storm/retrieval`
- expose `combine_ranks` helper for recency/authority/similarity fusion
- mark old vector-store chunks as archived during ingestion

## Testing
- `black src/tino_storm/utils.py src/tino_storm/retrieval/rrf.py src/tino_storm/retrieval/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804fff17e08326ad629b4d6da3a06f