### PR TITLE
Implement event emitter for pipeline output

### DIFF
--- a/src/tino_storm/__init__.py
+++ b/src/tino_storm/__init__.py
@@ -13,6 +13,9 @@ __all__ = [
     "CollaborativeStormLMConfigs",
     "RunnerArgument",
     "CoStormRunner",
+    "ResearchAdded",
+    "DocGenerated",
+    "event_emitter",
 ]
 
 __version__ = "1.1.0"
@@ -30,6 +33,9 @@ _ATTR_MAP = {
     ),
     "RunnerArgument": ("tino_storm.collaborative_storm.engine", "RunnerArgument"),
     "CoStormRunner": ("tino_storm.collaborative_storm.engine", "CoStormRunner"),
+    "ResearchAdded": ("tino_storm.events", "ResearchAdded"),
+    "DocGenerated": ("tino_storm.events", "DocGenerated"),
+    "event_emitter": ("tino_storm.events", "event_emitter"),
 }
 
 
@@ -41,4 +47,3 @@ def __getattr__(name: str):
         globals()[name] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-

--- a/src/tino_storm/events.py
+++ b/src/tino_storm/events.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Type, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .storm_wiki.modules.storm_dataclass import StormInformationTable, StormArticle
+
+
+@dataclass
+class ResearchAdded:
+    """Event emitted when new research is ingested."""
+
+    topic: str
+    information_table: "StormInformationTable"
+
+
+@dataclass
+class DocGenerated:
+    """Event emitted when a document is generated."""
+
+    topic: str
+    article: "StormArticle"
+
+
+class EventEmitter:
+    def __init__(self) -> None:
+        self._subscribers: Dict[Type[Any], List[Callable[[Any], None]]] = {}
+
+    def subscribe(self, event_type: Type[Any], handler: Callable[[Any], None]) -> None:
+        self._subscribers.setdefault(event_type, []).append(handler)
+
+    def emit(self, event: Any) -> None:
+        for handler in self._subscribers.get(type(event), []):
+            handler(event)
+
+
+event_emitter = EventEmitter()


### PR DESCRIPTION
## Summary
- add new `ResearchAdded` and `DocGenerated` dataclasses
- expose a simple `EventEmitter` and default instance
- emit events after research ingestion and article generation
- allow custom event emitter via `STORMWikiRunner` constructor

## Testing
- `pre-commit run --files src/tino_storm/events.py src/tino_storm/storm_wiki/engine.py src/tino_storm/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804ff62fb8832683488886b8e0ffdc