### PR TITLE
Add minimal ResearchSkill modules

### DIFF
--- a/examples/research_skill_example.py
+++ b/examples/research_skill_example.py
@@ -1,0 +1,14 @@
+"""Example usage of the lightweight ResearchSkill."""
+
+from tino_storm.skills import ResearchSkill
+
+
+def main():
+    skill = ResearchSkill(cloud_allowed=False)
+    topic = "The Eiffel Tower"
+    result = skill(topic, vault=None)
+    print({"outline": result.outline, "draft": result.draft})
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tino_storm/__init__.py
+++ b/src/tino_storm/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "CollaborativeStormLMConfigs",
     "RunnerArgument",
     "CoStormRunner",
+    "ResearchSkill",
 ]
 
 __version__ = "1.1.0"
@@ -30,6 +31,7 @@ _ATTR_MAP = {
     ),
     "RunnerArgument": ("tino_storm.collaborative_storm.engine", "RunnerArgument"),
     "CoStormRunner": ("tino_storm.collaborative_storm.engine", "CoStormRunner"),
+    "ResearchSkill": ("tino_storm.skills", "ResearchSkill"),
 }
 
 
@@ -41,4 +43,3 @@ def __getattr__(name: str):
         globals()[name] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-

--- a/src/tino_storm/skills/__init__.py
+++ b/src/tino_storm/skills/__init__.py
@@ -1,0 +1,19 @@
+"""Light-weight research skill modules."""
+
+from importlib import import_module
+
+__all__ = ["ResearchSkill"]
+
+_ATTR_MAP = {
+    "ResearchSkill": ("tino_storm.skills.research", "ResearchSkill"),
+}
+
+
+def __getattr__(name: str):
+    if name in _ATTR_MAP:
+        module_name, attr = _ATTR_MAP[name]
+        module = import_module(module_name)
+        value = getattr(module, attr)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/tino_storm/skills/research.py
+++ b/src/tino_storm/skills/research.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Dict, Any
+
+import dspy
+
+
+class OutlineSignature(dspy.Signature):
+    """Generate a brief outline for the topic."""
+
+    topic = dspy.InputField("topic to research")
+    outline = dspy.OutputField("outline")
+
+
+class DraftSignature(dspy.Signature):
+    """Generate a short draft article from the outline."""
+
+    topic = dspy.InputField("topic")
+    outline = dspy.InputField("outline")
+    draft = dspy.OutputField("draft article")
+
+
+class OutlineModule(dspy.Module):
+    """Module that proposes an outline for a research topic."""
+
+    EVAL_SET = [
+        dspy.Example(topic="Photosynthesis", outline="# Introduction"),
+        dspy.Example(topic="Eiffel Tower", outline="# History"),
+    ]
+
+    def __init__(self, engine: Optional[dspy.LM] = None):
+        super().__init__()
+        self.engine = engine or dspy.LM("gpt-3.5-turbo")
+        self.generate = dspy.Predict(OutlineSignature)
+
+    def forward(self, topic: str) -> dspy.Prediction:
+        with dspy.settings.context(lm=self.engine):
+            return self.generate(topic=topic)
+
+
+class DraftModule(dspy.Module):
+    """Module that expands an outline into a short draft."""
+
+    EVAL_SET = [
+        dspy.Example(
+            topic="Photosynthesis",
+            outline="# Introduction",
+            draft="Photosynthesis is the process by which plants convert light...",
+        )
+    ]
+
+    def __init__(self, engine: Optional[dspy.LM] = None):
+        super().__init__()
+        self.engine = engine or dspy.LM("gpt-3.5-turbo")
+        self.generate = dspy.Predict(DraftSignature)
+
+    def forward(self, topic: str, outline: str) -> dspy.Prediction:
+        with dspy.settings.context(lm=self.engine):
+            return self.generate(topic=topic, outline=outline)
+
+
+@dataclass
+class ResearchResult:
+    outline: str
+    draft: str
+
+
+class ResearchSkill:
+    """Simple skill that wraps OutlineModule and DraftModule."""
+
+    def __init__(self, cloud_allowed: bool = False):
+        if cloud_allowed:
+            lm = dspy.LM("gpt-3.5-turbo")
+        else:
+            lm = dspy.HFModel("google/flan-t5-small")
+        self.outline = OutlineModule(engine=lm)
+        self.draft = DraftModule(engine=lm)
+
+    def __call__(
+        self, topic: str, vault: Optional[Dict[str, Any]] = None
+    ) -> ResearchResult:
+        outline_pred = self.outline(topic=topic)
+        draft_pred = self.draft(topic=topic, outline=outline_pred.outline)
+        return ResearchResult(outline=outline_pred.outline, draft=draft_pred.draft)


### PR DESCRIPTION
## Summary
- implement simple `OutlineModule` and `DraftModule`
- build a lightweight `ResearchSkill` wrapper
- expose `ResearchSkill` via package `__init__`
- add example showing how to call the skill

## Testing
- `black src/tino_storm/skills/__init__.py src/tino_storm/skills/research.py src/tino_storm/__init__.py examples/research_skill_example.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804ffba3bc83269f10a7389698ae21