### PR TITLE
Add ingest watcher command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ $ tino-storm research "Quantum computing" --output-dir ./results
 
 # Start the API server
 $ tino-storm serve --host 0.0.0.0 --port 8000
+
+# Watch a directory for dropped files/URLs
+$ tino-storm ingest --root ./vault
 ```
 
 ## Programmatic API

--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -1,8 +1,8 @@
 import argparse
-import os
 import uvicorn
 
 from .api import app, run_research
+from .ingest import start_watcher
 
 
 def main(argv=None):
@@ -31,6 +31,11 @@ def main(argv=None):
     serve_p.add_argument("--host", default="0.0.0.0")
     serve_p.add_argument("--port", type=int, default=8000)
 
+    ingest_p = subparsers.add_parser(
+        "ingest", help="Watch a directory for dropped files"
+    )
+    ingest_p.add_argument("--root", help="Directory to watch")
+
     args = parser.parse_args(argv)
 
     if args.command == "research":
@@ -44,6 +49,8 @@ def main(argv=None):
         )
     elif args.command == "serve":
         uvicorn.run(app, host=args.host, port=args.port)
+    elif args.command == "ingest":
+        start_watcher(root=args.root)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point


### PR DESCRIPTION
## Summary
- add `ingest` subcommand to CLI
- show how to run `ingest` in the README

## Testing
- `ruff check src/tino_storm/cli.py`
- `black src/tino_storm/cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d365f0248326b3b6ca1b1638083b