### PR TITLE
Refine hash utilities

### DIFF
--- a/knowledge_storm/interface.py
+++ b/knowledge_storm/interface.py
@@ -65,15 +65,8 @@ class Information:
         self.title = title
         self.url = url
         self.meta = meta if meta is not None else {}
-        self.citation_uuid = -1
 
-    def __hash__(self):
-        return hash(
-            (
-                self.url,
-                tuple(sorted(self.snippets)),
-            )
-        )
+        self.citation_uuid = -1
 
     def __eq__(self, other):
         if not isinstance(other, Information):
@@ -94,7 +87,8 @@ class Information:
         """Generate a string representation of relevant meta information."""
         return f"Question: {self.meta.get('question', '')}, Query: {self.meta.get('query', '')}"
 
-    def _md5_hash(self, value):
+    @staticmethod
+    def _md5_hash(value):
         """Generate an MD5 hash for a given value."""
         if isinstance(value, (dict, list, tuple)):
             value = json.dumps(value, sort_keys=True)

--- a/src/tino_storm/interface.py
+++ b/src/tino_storm/interface.py
@@ -65,15 +65,8 @@ class Information:
         self.title = title
         self.url = url
         self.meta = meta if meta is not None else {}
-        self.citation_uuid = -1
 
-    def __hash__(self):
-        return hash(
-            (
-                self.url,
-                tuple(sorted(self.snippets)),
-            )
-        )
+        self.citation_uuid = -1
 
     def __eq__(self, other):
         if not isinstance(other, Information):
@@ -94,7 +87,8 @@ class Information:
         """Generate a string representation of relevant meta information."""
         return f"Question: {self.meta.get('question', '')}, Query: {self.meta.get('query', '')}"
 
-    def _md5_hash(self, value):
+    @staticmethod
+    def _md5_hash(value):
         """Generate an MD5 hash for a given value."""
         if isinstance(value, (dict, list, tuple)):
             value = json.dumps(value, sort_keys=True)


### PR DESCRIPTION
## Summary
- make the private `_md5_hash` helper static in both `Information` classes
- keep MD5-based `__hash__` implementation

## Testing
- `ruff check knowledge_storm/interface.py src/tino_storm/interface.py`
- `black knowledge_storm/interface.py src/tino_storm/interface.py --check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880d36443348326aa0dc791d4ab0c50