### PR TITLE
Handle social media manifests in ingest

### DIFF
--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -35,6 +35,15 @@ def main(argv=None):
         "ingest", help="Watch a directory for dropped files"
     )
     ingest_p.add_argument("--root", help="Directory to watch")
+    ingest_p.add_argument("--twitter-limit", type=int, help="Max tweets per manifest")
+    ingest_p.add_argument(
+        "--reddit-limit", type=int, help="Max reddit posts per manifest"
+    )
+    ingest_p.add_argument(
+        "--fourchan-limit", type=int, help="Max 4chan posts per manifest"
+    )
+    ingest_p.add_argument("--reddit-client-id")
+    ingest_p.add_argument("--reddit-client-secret")
 
     args = parser.parse_args(argv)
 
@@ -50,7 +59,14 @@ def main(argv=None):
     elif args.command == "serve":
         uvicorn.run(app, host=args.host, port=args.port)
     elif args.command == "ingest":
-        start_watcher(root=args.root)
+        start_watcher(
+            root=args.root,
+            twitter_limit=args.twitter_limit,
+            reddit_limit=args.reddit_limit,
+            fourchan_limit=args.fourchan_limit,
+            reddit_client_id=args.reddit_client_id,
+            reddit_client_secret=args.reddit_client_secret,
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/src/tino_storm/ingest/watcher.py
+++ b/src/tino_storm/ingest/watcher.py
@@ -11,13 +11,24 @@ from watchdog.observers import Observer
 import chromadb
 import trafilatura
 
+from ..ingestion import TwitterScraper, RedditScraper, FourChanScraper
+
 from ..events import ResearchAdded, event_emitter
 
 
 class VaultIngestHandler(FileSystemEventHandler):
-    """Watch a vault directory and ingest dropped files or URLs."""
+    """Watch a vault directory and ingest dropped files, URLs or manifests."""
 
-    def __init__(self, root: str, chroma_path: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        root: str,
+        chroma_path: Optional[str] = None,
+        twitter_limit: Optional[int] = None,
+        reddit_limit: Optional[int] = None,
+        fourchan_limit: Optional[int] = None,
+        reddit_client_id: Optional[str] = None,
+        reddit_client_secret: Optional[str] = None,
+    ) -> None:
         self.root = Path(root).expanduser().resolve()
         chroma_root = Path(
             chroma_path
@@ -27,6 +38,21 @@ class VaultIngestHandler(FileSystemEventHandler):
         ).expanduser()
         chroma_root.mkdir(parents=True, exist_ok=True)
         self.client = chromadb.PersistentClient(path=str(chroma_root))
+        self.twitter_limit = twitter_limit or int(
+            os.environ.get("STORM_TWITTER_LIMIT", 20)
+        )
+        self.reddit_limit = reddit_limit or int(
+            os.environ.get("STORM_REDDIT_LIMIT", 20)
+        )
+        self.fourchan_limit = fourchan_limit or int(
+            os.environ.get("STORM_FOURCHAN_LIMIT", 20)
+        )
+        self.reddit_client_id = reddit_client_id or os.environ.get(
+            "STORM_REDDIT_CLIENT_ID"
+        )
+        self.reddit_client_secret = reddit_client_secret or os.environ.get(
+            "STORM_REDDIT_CLIENT_SECRET"
+        )
         super().__init__()
 
     def _ingest_text(self, text: str, source: str, vault: str) -> None:
@@ -41,7 +67,8 @@ class VaultIngestHandler(FileSystemEventHandler):
         )
 
     def _handle_file(self, path: Path, vault: str) -> None:
-        if path.suffix.lower() in {".url", ".urls"}:
+        suffix = path.suffix.lower()
+        if suffix in {".url", ".urls"}:
             lines = [
                 line.strip() for line in path.read_text().splitlines() if line.strip()
             ]
@@ -50,6 +77,49 @@ class VaultIngestHandler(FileSystemEventHandler):
                 text = trafilatura.extract(html) or ""
                 if text:
                     self._ingest_text(text, url, vault)
+        elif suffix == ".twitter":
+            query = path.read_text().strip()
+            scraper = TwitterScraper()
+            for post in scraper.search(query, limit=self.twitter_limit):
+                text = post.get("text", "")
+                if post.get("images_text"):
+                    text += "\n" + "\n".join(post["images_text"])
+                self._ingest_text(text, post.get("url", query), vault)
+        elif suffix == ".reddit":
+            lines = [ln.strip() for ln in path.read_text().splitlines() if ln.strip()]
+            if not lines:
+                return
+            subreddit = lines[0]
+            query = lines[1] if len(lines) > 1 else ""
+            scraper = RedditScraper(
+                client_id=self.reddit_client_id,
+                client_secret=self.reddit_client_secret,
+            )
+            for post in scraper.search(subreddit, query, limit=self.reddit_limit):
+                text = (post.get("title", "") + "\n" + post.get("text", "")).strip()
+                if post.get("images_text"):
+                    text += "\n" + "\n".join(post["images_text"])
+                self._ingest_text(text, post.get("url", query), vault)
+        elif suffix == ".4chan":
+            lines = [ln.strip() for ln in path.read_text().splitlines() if ln.strip()]
+            if len(lines) < 2:
+                return
+            board = lines[0]
+            try:
+                thread_no = int(lines[1])
+            except ValueError:
+                return
+            scraper = FourChanScraper()
+            posts = scraper.fetch_thread(board, thread_no)[: self.fourchan_limit]
+            for post in posts:
+                text = post.get("text", "")
+                if post.get("images_text"):
+                    text += "\n" + "\n".join(post["images_text"])
+                self._ingest_text(
+                    text,
+                    f"https://boards.4channel.org/{board}/thread/{thread_no}",
+                    vault,
+                )
         else:
             try:
                 text = path.read_text(encoding="utf-8")
@@ -70,14 +140,29 @@ class VaultIngestHandler(FileSystemEventHandler):
 
 
 def start_watcher(
-    root: Optional[str] = None, chroma_path: Optional[str] = None
+    root: Optional[str] = None,
+    chroma_path: Optional[str] = None,
+    *,
+    twitter_limit: Optional[int] = None,
+    reddit_limit: Optional[int] = None,
+    fourchan_limit: Optional[int] = None,
+    reddit_client_id: Optional[str] = None,
+    reddit_client_secret: Optional[str] = None,
 ) -> None:
-    """Start watching ``root`` for dropped files/URLs."""
+    """Start watching ``root`` for dropped files, URLs and manifests."""
 
     watch_root = Path(
         root or os.environ.get("STORM_VAULT_ROOT", "research")
     ).expanduser()
-    handler = VaultIngestHandler(str(watch_root), chroma_path=chroma_path)
+    handler = VaultIngestHandler(
+        str(watch_root),
+        chroma_path=chroma_path,
+        twitter_limit=twitter_limit,
+        reddit_limit=reddit_limit,
+        fourchan_limit=fourchan_limit,
+        reddit_client_id=reddit_client_id,
+        reddit_client_secret=reddit_client_secret,
+    )
     observer = Observer()
     observer.schedule(handler, str(watch_root), recursive=True)
     observer.start()

--- a/tests/test_research_skill.py
+++ b/tests/test_research_skill.py
@@ -11,7 +11,7 @@ from knowledge_storm.storm_wiki.modules.knowledge_curation import (  # noqa: E40
     DialogueTurn,
     StormInformationTable,
 )
-from knowledge_storm.storm_wiki.modules.callback import (
+from knowledge_storm.storm_wiki.modules.callback import (  # noqa: E402
     BaseCallbackHandler,
 )  # noqa: E402
 from tino_storm.core.interface import Information  # noqa: E402

--- a/tests/test_vault_ingest_handler.py
+++ b/tests/test_vault_ingest_handler.py
@@ -1,0 +1,90 @@
+import sys
+import types
+
+if "snscrape.modules.twitter" not in sys.modules:
+    mod = types.ModuleType("snscrape.modules.twitter")
+
+    class _DummyScraper:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_items(self):
+            return []
+
+    mod.TwitterSearchScraper = _DummyScraper
+    pkg = types.ModuleType("snscrape.modules")
+    setattr(pkg, "twitter", mod)
+    sys.modules["snscrape"] = types.ModuleType("snscrape")
+    sys.modules["snscrape.modules"] = pkg
+    sys.modules["snscrape.modules.twitter"] = mod
+
+from tino_storm.ingest.watcher import VaultIngestHandler
+
+
+class DummyScraper:
+    def __init__(self, results):
+        self._results = results
+
+    def search(self, *a, limit=20, **k):
+        return self._results
+
+    def fetch_thread(self, *a, **k):
+        return self._results
+
+
+def _run_handler(tmp_path, filename, content, monkeypatch, scraper_attr, results):
+    root = tmp_path / "vault"
+    vault = root / "topic"
+    vault.mkdir(parents=True)
+    file = vault / filename
+    file.write_text(content)
+    handler = VaultIngestHandler(str(root))
+    captured = []
+    monkeypatch.setattr(
+        handler, "_ingest_text", lambda text, src, v: captured.append((text, src, v))
+    )
+    monkeypatch.setattr(
+        "tino_storm.ingest.watcher." + scraper_attr,
+        lambda *a, **k: DummyScraper(results),
+    )
+    handler._handle_file(file, "topic")
+    return captured
+
+
+def test_handle_twitter(monkeypatch, tmp_path):
+    res = [{"text": "t", "url": "u"}]
+    captured = _run_handler(
+        tmp_path,
+        "q.twitter",
+        "q",
+        monkeypatch,
+        "TwitterScraper",
+        res,
+    )
+    assert captured and captured[0][0].startswith("t")
+
+
+def test_handle_reddit(monkeypatch, tmp_path):
+    res = [{"title": "ti", "text": "tx", "url": "u"}]
+    captured = _run_handler(
+        tmp_path,
+        "r.reddit",
+        "sub\nquery",
+        monkeypatch,
+        "RedditScraper",
+        res,
+    )
+    assert any("ti" in c[0] for c in captured)
+
+
+def test_handle_fourchan(monkeypatch, tmp_path):
+    res = [{"text": "p"}]
+    captured = _run_handler(
+        tmp_path,
+        "f.4chan",
+        "b\n123",
+        monkeypatch,
+        "FourChanScraper",
+        res,
+    )
+    assert captured[0][0] == "p"


### PR DESCRIPTION
## Summary
- add CLI flags for ingesting social media posts
- handle `.twitter`, `.reddit` and `.4chan` manifests
- support scraper limits and credentials
- test manifest ingestion

## Testing
- `pre-commit run --files src/tino_storm/cli.py src/tino_storm/ingest/watcher.py tests/test_vault_ingest_handler.py tests/test_research_skill.py`

------
https://chatgpt.com/codex/tasks/task_e_6880f1e9a4548326a8249efe4e299b16