### PR TITLE
Add ResearchModule and optimization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ from tino_storm.api import run_research
 run_research(topic="Quantum computing", output_dir="./results")
 ```
 
+The lightweight `ResearchSkill` can also be used directly. When cloud access is
+allowed you may tune its prompts using `optimize()`:
+
+```python
+from tino_storm.skills import ResearchSkill
+
+skill = ResearchSkill(cloud_allowed=True)
+skill.optimize()
+result = skill("The Eiffel Tower")
+```
+
 ## Ingesting your own data
 
 STORM can be grounded on a custom corpus by creating a Qdrant vector store and

--- a/examples/research_skill_example.py
+++ b/examples/research_skill_example.py
@@ -9,6 +9,9 @@ def main():
     result = skill(topic, vault=None)
     print({"outline": result.outline, "draft": result.draft})
 
+    if skill.cloud_allowed:
+        skill.optimize()
+
 
 if __name__ == "__main__":
     main()

--- a/src/tino_storm/skills/__init__.py
+++ b/src/tino_storm/skills/__init__.py
@@ -2,10 +2,11 @@
 
 from importlib import import_module
 
-__all__ = ["ResearchSkill"]
+__all__ = ["ResearchSkill", "ResearchModule"]
 
 _ATTR_MAP = {
     "ResearchSkill": ("tino_storm.skills.research", "ResearchSkill"),
+    "ResearchModule": ("tino_storm.skills.research_module", "ResearchModule"),
 }
 
 

--- a/src/tino_storm/skills/research.py
+++ b/src/tino_storm/skills/research.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 import dspy
+
+from dspy.teleprompt import BootstrapFewShot
+
+from .research_module import ResearchModule, ResearchResult
 
 
 class OutlineSignature(dspy.Signature):
@@ -60,26 +63,56 @@ class DraftModule(dspy.Module):
             return self.generate(topic=topic, outline=outline)
 
 
-@dataclass
-class ResearchResult:
-    outline: str
-    draft: str
-
-
 class ResearchSkill:
     """Simple skill that wraps OutlineModule and DraftModule."""
 
-    def __init__(self, cloud_allowed: bool = False):
+    DEFAULT_EVAL_SET = OutlineModule.EVAL_SET + DraftModule.EVAL_SET
+
+    def __init__(
+        self,
+        cloud_allowed: bool = False,
+        eval_sets: Optional[Dict[str, list[dspy.Example]]] = None,
+    ):
+        """Create the skill.
+
+        Parameters
+        ----------
+        cloud_allowed:
+            Whether remote LMs may be used.
+        eval_sets:
+            Optional mapping of vault names to DSPy ``Example`` lists used for optimization.
+        """
+
+        self.cloud_allowed = cloud_allowed
         if cloud_allowed:
             lm = dspy.LM("gpt-3.5-turbo")
         else:
             lm = dspy.HFModel("google/flan-t5-small")
         self.outline = OutlineModule(engine=lm)
         self.draft = DraftModule(engine=lm)
+        self.module = ResearchModule(self.outline, self.draft)
+        self.eval_sets: Dict[str, list[dspy.Example]] = {
+            "default": self.DEFAULT_EVAL_SET
+        }
+        if eval_sets:
+            self.eval_sets.update(eval_sets)
 
     def __call__(
         self, topic: str, vault: Optional[Dict[str, Any]] = None
     ) -> ResearchResult:
+        if getattr(self.module, "_compiled", False):
+            return self.module(topic=topic)
+
         outline_pred = self.outline(topic=topic)
         draft_pred = self.draft(topic=topic, outline=outline_pred.outline)
         return ResearchResult(outline=outline_pred.outline, draft=draft_pred.draft)
+
+    def optimize(self, vault: str = "default") -> None:
+        """Optimize prompts using DSPy when cloud access is allowed."""
+
+        if not self.cloud_allowed:
+            return
+
+        eval_set = self.eval_sets.get(vault, self.DEFAULT_EVAL_SET)
+        trainer = BootstrapFewShot()
+        trainer.compile(self.module, trainset=eval_set, valset=eval_set)

--- a/src/tino_storm/skills/research_module.py
+++ b/src/tino_storm/skills/research_module.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import dspy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from .research import OutlineModule, DraftModule
+
+
+class ResearchSignature(dspy.Signature):
+    """Run outline and drafting in a single module."""
+
+    topic = dspy.InputField("topic to research")
+    outline = dspy.OutputField("brief outline")
+    draft = dspy.OutputField("draft article")
+
+
+@dataclass
+class ResearchResult:
+    outline: str
+    draft: str
+
+
+class ResearchModule(dspy.Module):
+    """DSPy module that chains OutlineModule and DraftModule."""
+
+    def __init__(self, outline: "OutlineModule", draft: "DraftModule") -> None:
+        super().__init__()
+        self.outline_module = outline
+        self.draft_module = draft
+
+    def forward(self, topic: str) -> ResearchResult:  # type: ignore[override]
+        outline_pred = self.outline_module(topic=topic)
+        draft_pred = self.draft_module(topic=topic, outline=outline_pred.outline)
+        return ResearchResult(outline=outline_pred.outline, draft=draft_pred.draft)

--- a/tests/test_research_module.py
+++ b/tests/test_research_module.py
@@ -1,0 +1,103 @@
+import sys
+import types
+
+# Provide a minimal dspy.teleprompt stub if missing
+if "dspy.teleprompt" not in sys.modules:
+    tp = types.ModuleType("dspy.teleprompt")
+
+    class BootstrapFewShot:
+        def compile(self, student, *, trainset, valset=None, teacher=None):
+            return student
+
+    tp.BootstrapFewShot = BootstrapFewShot
+    sys.modules["dspy.teleprompt"] = tp
+
+import dspy
+
+if not hasattr(dspy, "Example"):
+
+    class Example:
+        def __init__(self, *a, **k):
+            pass
+
+    class Signature:
+        pass
+
+    class InputField:
+        def __init__(self, *a, **k):
+            pass
+
+    class OutputField:
+        def __init__(self, *a, **k):
+            pass
+
+    class Predict:
+        def __init__(self, *a, **k):
+            pass
+
+        def __call__(self, *a, **k):
+            return types.SimpleNamespace()
+
+    class Module:
+        def __init__(self, *a, **k):
+            pass
+
+        def __call__(self, *a, **k):
+            return self.forward(*a, **k)
+
+    class LM:
+        def __init__(self, *a, **k):
+            pass
+
+    class HFModel:
+        def __init__(self, *a, **k):
+            pass
+
+    dspy.Example = Example
+    dspy.Signature = Signature
+    dspy.InputField = InputField
+    dspy.OutputField = OutputField
+    dspy.Predict = Predict
+    dspy.Module = Module
+    dspy.LM = LM
+    dspy.HFModel = HFModel
+    dspy.teleprompt = types.ModuleType("teleprompt")
+    dspy.teleprompt.BootstrapFewShot = BootstrapFewShot
+
+from tino_storm.skills.research import ResearchSkill
+
+
+class DummyPredict:
+    def __init__(self, value):
+        self._value = value
+
+    def __call__(self, *a, **k):
+        return types.SimpleNamespace(**self._value)
+
+
+def test_research_skill_call(monkeypatch):
+    skill = ResearchSkill(cloud_allowed=False)
+    monkeypatch.setattr(
+        skill.outline, "forward", lambda *a, **k: types.SimpleNamespace(outline="o")
+    )
+    monkeypatch.setattr(
+        skill.draft,
+        "forward",
+        lambda *a, **k: types.SimpleNamespace(draft="d"),
+    )
+    result = skill("topic")
+    assert result.outline == "o"
+    assert result.draft == "d"
+
+
+def test_optimize_runs(monkeypatch):
+    skill = ResearchSkill(cloud_allowed=True)
+
+    def dummy_compile(self, student, *, trainset, valset=None, teacher=None):
+        dummy_compile.called = True
+        return student
+
+    dummy_compile.called = False
+    monkeypatch.setattr(dspy.teleprompt.BootstrapFewShot, "compile", dummy_compile)
+    skill.optimize()
+    assert dummy_compile.called

--- a/tests/test_research_skill.py
+++ b/tests/test_research_skill.py
@@ -11,9 +11,9 @@ from knowledge_storm.storm_wiki.modules.knowledge_curation import (  # noqa: E40
     DialogueTurn,
     StormInformationTable,
 )
-from knowledge_storm.storm_wiki.modules.callback import (
+from knowledge_storm.storm_wiki.modules.callback import (  # noqa: E402
     BaseCallbackHandler,
-)  # noqa: E402
+)
 from tino_storm.core.interface import Information  # noqa: E402
 
 


### PR DESCRIPTION
## Summary
- implement `ResearchModule` to chain `OutlineModule` and `DraftModule`
- allow optimizing prompts via `ResearchSkill.optimize`
- export the new module
- document ResearchSkill optimization
- update example
- add tests

## Testing
- `pre-commit run --files src/tino_storm/skills/research.py src/tino_storm/skills/research_module.py src/tino_storm/skills/__init__.py README.md examples/research_skill_example.py tests/test_research_module.py tests/test_research_skill.py`

------
https://chatgpt.com/codex/tasks/task_e_6880f1eb29c88326bf75e2a7b14cdaf8