### PR TITLE
Add dependency stubs for tests

### DIFF
--- a/src/tino_storm/ingest/watcher.py
+++ b/src/tino_storm/ingest/watcher.py
@@ -11,6 +11,8 @@ from watchdog.observers import Observer
 import chromadb
 import trafilatura
 
+from ..ingestion import TwitterScraper, RedditScraper, FourChanScraper
+
 from ..security import get_passphrase
 from ..security.encrypted_chroma import EncryptedChroma
 
@@ -44,6 +46,12 @@ class VaultIngestHandler(FileSystemEventHandler):
             self.client = EncryptedChroma(str(chroma_root), passphrase=passphrase)
         else:
             self.client = chromadb.PersistentClient(path=str(chroma_root))
+
+        self.twitter_limit = twitter_limit
+        self.reddit_limit = reddit_limit
+        self.fourchan_limit = fourchan_limit
+        self.reddit_client_id = reddit_client_id
+        self.reddit_client_secret = reddit_client_secret
 
         super().__init__()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import builtins
 import pytest
 
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -37,6 +38,23 @@ for _missing in [
     "sklearn",
     "qdrant_client",
     "pandas",
+    "numpy",
+    "cryptography",
+    "requests",
+    "pytz",
+    "watchdog",
+    "yaml",
+    "chromadb",
+    "uvicorn",
+    "fastapi",
+    "pydantic",
+    "snscrape",
+    "snscrape.modules",
+    "snscrape.modules.twitter",
+    "PIL",
+    "PIL.Image",
+    "pytesseract",
+    "praw",
 ]:
     if _missing not in sys.modules:
         module = types.ModuleType(_missing)
@@ -76,6 +94,9 @@ for _missing in [
             module.BeautifulSoup = BeautifulSoup
         elif _missing == "httpx":
 
+            class HTTPError(Exception):
+                pass
+
             class Client:
                 def __init__(self, *a, **k):
                     pass
@@ -83,7 +104,12 @@ for _missing in [
                 def get(self, *a, **k):
                     return types.SimpleNamespace(status_code=200, content=b"")
 
+            def get(*a, **k):
+                return Client().get(*a, **k)
+
             module.Client = Client
+            module.HTTPError = HTTPError
+            module.get = get
         elif _missing == "toml":
 
             def load(*a, **k):
@@ -134,14 +160,21 @@ for _missing in [
             metrics_mod = types.ModuleType("sklearn.metrics")
             pairwise_mod = types.ModuleType("sklearn.metrics.pairwise")
 
-            import numpy as _np
+            def _dot(u, v):
+                return sum(x * y for x, y in zip(u, v))
+
+            def _norm(v):
+                return sum(x * x for x in v) ** 0.5
 
             def cosine_similarity(a, b):
-                a = _np.array(a)
-                b = _np.array(b)
-                a_norm = a / (_np.linalg.norm(a, axis=1, keepdims=True) + 1e-8)
-                b_norm = b / (_np.linalg.norm(b, axis=1, keepdims=True) + 1e-8)
-                return a_norm @ b_norm.T
+                result = []
+                for vec_a in a:
+                    row = []
+                    for vec_b in b:
+                        denom = (_norm(vec_a) * _norm(vec_b)) + 1e-8
+                        row.append(_dot(vec_a, vec_b) / denom)
+                    result.append(row)
+                return result
 
             pairwise_mod.cosine_similarity = cosine_similarity
             metrics_mod.pairwise = pairwise_mod
@@ -219,6 +252,342 @@ for _missing in [
             pandas_mod.read_csv = read_csv
             pandas_mod.DataFrame = DataFrame
             module = pandas_mod
+        elif _missing == "numpy":
+            numpy_mod = types.ModuleType("numpy")
+
+            def array(obj):
+                return list(obj)
+
+            def argsort(seq):
+                return sorted(range(len(seq)), key=lambda i: seq[i])
+
+            def max(arr, axis=None):
+                if axis is None:
+                    return builtins.max(arr)
+                if axis == 1:
+                    return [builtins.max(row) for row in arr]
+                return builtins.max(arr)
+
+            def clip(arr, a_min, a_max):
+                return [min(max(x, a_min), a_max) for x in arr]
+
+            def where(cond, x, y):
+                return [xi if ci else yi for ci, xi, yi in zip(cond, x, y)]
+
+            class ndarray(list):
+                @property
+                def size(self):
+                    if not self:
+                        return 0
+                    if isinstance(self[0], list):
+                        return len(self) * len(self[0])
+                    return len(self)
+
+                def __getitem__(self, idx):
+                    if isinstance(idx, list):
+                        return ndarray([super().__getitem__(i) for i in idx])
+                    return super().__getitem__(idx)
+
+            numpy_mod.array = lambda obj: ndarray(obj)
+            numpy_mod.argsort = argsort
+            numpy_mod.max = max
+            numpy_mod.clip = clip
+            numpy_mod.where = where
+            numpy_mod.ndarray = ndarray
+            sys.modules["numpy"] = numpy_mod
+            module = numpy_mod
+        elif _missing == "cryptography":
+            crypto_mod = types.ModuleType("cryptography")
+            fernet_mod = types.ModuleType("cryptography.fernet")
+            hazmat_mod = types.ModuleType("cryptography.hazmat")
+            backends_mod = types.ModuleType("cryptography.hazmat.backends")
+            primitives_mod = types.ModuleType("cryptography.hazmat.primitives")
+            hashes_mod = types.ModuleType("cryptography.hazmat.primitives.hashes")
+            kdf_mod = types.ModuleType("cryptography.hazmat.primitives.kdf")
+            pbkdf2_mod = types.ModuleType("cryptography.hazmat.primitives.kdf.pbkdf2")
+
+            class Fernet:
+                def __init__(self, key: bytes):
+                    self.key = key
+
+                def encrypt(self, data: bytes) -> bytes:
+                    return b"enc:" + data
+
+                def decrypt(self, token: bytes) -> bytes:
+                    if token.startswith(b"enc:"):
+                        return token[4:]
+                    return token
+
+            def default_backend():
+                return None
+
+            class SHA256:
+                pass
+
+            class PBKDF2HMAC:
+                def __init__(self, algorithm, length, salt, iterations, backend=None):
+                    self.length = length
+                    self.salt = salt
+                    self.iterations = iterations
+
+                def derive(self, data: bytes) -> bytes:
+                    import hashlib
+
+                    return hashlib.pbkdf2_hmac(
+                        "sha256", data, self.salt, self.iterations, dklen=self.length
+                    )
+
+            fernet_mod.Fernet = Fernet
+            backends_mod.default_backend = default_backend
+            hashes_mod.SHA256 = SHA256
+            pbkdf2_mod.PBKDF2HMAC = PBKDF2HMAC
+            kdf_mod.pbkdf2 = pbkdf2_mod
+            primitives_mod.hashes = hashes_mod
+            primitives_mod.kdf = kdf_mod
+            hazmat_mod.backends = backends_mod
+            hazmat_mod.primitives = primitives_mod
+            crypto_mod.fernet = fernet_mod
+            crypto_mod.hazmat = hazmat_mod
+            module = crypto_mod
+            sys.modules["cryptography.fernet"] = fernet_mod
+            sys.modules["cryptography.hazmat"] = hazmat_mod
+            sys.modules["cryptography.hazmat.backends"] = backends_mod
+            sys.modules["cryptography.hazmat.primitives"] = primitives_mod
+            sys.modules["cryptography.hazmat.primitives.hashes"] = hashes_mod
+            sys.modules["cryptography.hazmat.primitives.kdf"] = kdf_mod
+            sys.modules["cryptography.hazmat.primitives.kdf.pbkdf2"] = pbkdf2_mod
+        elif _missing == "requests":
+
+            def _resp(*a, **k):
+                return types.SimpleNamespace(
+                    status_code=200, json=lambda: {}, text="", content=b""
+                )
+
+            class Session:
+                def get(self, *a, **k):
+                    return _resp()
+
+                def post(self, *a, **k):
+                    return _resp()
+
+            module.get = lambda *a, **k: _resp()
+            module.post = lambda *a, **k: _resp()
+            module.Session = Session
+        elif _missing == "pytz":
+
+            class _TZ:
+                def __init__(self, name: str):
+                    self.name = name
+
+                def localize(self, dt):
+                    return dt
+
+            module.timezone = lambda name: _TZ(name)
+            module.utc = _TZ("UTC")
+        elif _missing == "watchdog":
+            observers_mod = types.ModuleType("watchdog.observers")
+            events_mod = types.ModuleType("watchdog.events")
+
+            class FileSystemEventHandler:
+                pass
+
+            class Observer:
+                def schedule(self, *a, **k):
+                    pass
+
+                def start(self):
+                    pass
+
+                def stop(self):
+                    pass
+
+                def join(self, *a, **k):
+                    pass
+
+            observers_mod.Observer = Observer
+            events_mod.FileSystemEventHandler = FileSystemEventHandler
+            module.observers = observers_mod
+            module.events = events_mod
+            sys.modules["watchdog.observers"] = observers_mod
+            sys.modules["watchdog.events"] = events_mod
+        elif _missing == "yaml":
+
+            def safe_load(*a, **k):
+                return {}
+
+            def dump(data, *a, **k):
+                return ""
+
+            module.safe_load = safe_load
+            module.dump = dump
+        elif _missing == "chromadb":
+            chroma_mod = types.ModuleType("chromadb")
+            api_mod = types.ModuleType("chromadb.api")
+            config_mod = types.ModuleType("chromadb.config")
+
+            class DummyCollection:
+                def __init__(self):
+                    self.docs = []
+                    self.ids = []
+
+                def add(self, documents=None, ids=None, **kw):
+                    if documents:
+                        self.docs.extend(documents)
+                    if ids:
+                        self.ids.extend(ids)
+
+                def query(self, **kw):
+                    return {"documents": [self.docs]}
+
+            class PersistentClient:
+                def __init__(self, *a, **k):
+                    self.collections = {}
+
+                def get_or_create_collection(self, name, **kw):
+                    if name not in self.collections:
+                        self.collections[name] = DummyCollection()
+                    return self.collections[name]
+
+            api_mod.Collection = DummyCollection
+
+            class Settings:
+                def __init__(self, *a, **k):
+                    pass
+
+            config_mod.Settings = Settings
+            chroma_mod.PersistentClient = PersistentClient
+            sys.modules["chromadb.api"] = api_mod
+            sys.modules["chromadb.config"] = config_mod
+            module = chroma_mod
+        elif _missing == "yaml":
+
+            def safe_load(*a, **k):
+                return {}
+
+            def dump(data, *a, **k):
+                return ""
+
+            module.safe_load = safe_load
+            module.dump = dump
+        elif _missing == "uvicorn":
+
+            class Config:
+                def __init__(self, *a, **k):
+                    pass
+
+            class Server:
+                def __init__(self, *a, **k):
+                    pass
+
+                def run(self):
+                    pass
+
+            module.Config = Config
+            module.Server = Server
+        elif _missing == "fastapi":
+
+            class FastAPI:
+                def __init__(self, *a, **k):
+                    pass
+
+                def get(self, *a, **k):
+                    def decorator(fn):
+                        return fn
+
+                    return decorator
+
+                def post(self, *a, **k):
+                    def decorator(fn):
+                        return fn
+
+                    return decorator
+
+            module.FastAPI = FastAPI
+        elif _missing == "pydantic":
+
+            class BaseModel:
+                def __init__(self, **data):
+                    for k, v in data.items():
+                        setattr(self, k, v)
+
+                model_config = types.SimpleNamespace()
+
+            module.BaseModel = BaseModel
+        elif _missing.startswith("snscrape"):
+            if _missing in ("snscrape", "snscrape.modules", "snscrape.modules.twitter"):
+                twitter_mod = types.ModuleType("snscrape.modules.twitter")
+
+                class TwitterSearchScraper:
+                    def __init__(self, *a, **k):
+                        pass
+
+                    def get_items(self):
+                        return []
+
+                twitter_mod.TwitterSearchScraper = TwitterSearchScraper
+                sys.modules["snscrape.modules.twitter"] = twitter_mod
+                if "snscrape.modules" not in sys.modules:
+                    modules_mod = types.ModuleType("snscrape.modules")
+                    sys.modules["snscrape.modules"] = modules_mod
+                else:
+                    modules_mod = sys.modules["snscrape.modules"]
+                modules_mod.twitter = twitter_mod
+                if "snscrape" not in sys.modules:
+                    sns_mod = types.ModuleType("snscrape")
+                    sys.modules["snscrape"] = sns_mod
+                else:
+                    sns_mod = sys.modules["snscrape"]
+                sns_mod.modules = modules_mod
+                if _missing == "snscrape.modules.twitter":
+                    module = twitter_mod
+                elif _missing == "snscrape.modules":
+                    module = modules_mod
+                else:
+                    module = sns_mod
+        elif _missing == "PIL" or _missing == "PIL.Image":
+            pil_mod = types.ModuleType("PIL")
+            image_mod = types.ModuleType("PIL.Image")
+
+            class Image:
+                def __init__(self, *a, **k):
+                    pass
+
+                @staticmethod
+                def open(*a, **k):
+                    return Image()
+
+            image_mod.Image = Image
+            pil_mod.Image = Image
+            sys.modules.setdefault("PIL", pil_mod)
+            sys.modules.setdefault("PIL.Image", image_mod)
+            module = pil_mod if _missing == "PIL" else image_mod
+        elif _missing == "pytesseract":
+            pytesseract_mod = types.ModuleType("pytesseract")
+
+            def image_to_string(*a, **k):
+                return ""
+
+            pytesseract_mod.image_to_string = image_to_string
+            module = pytesseract_mod
+        elif _missing == "praw":
+            praw_mod = types.ModuleType("praw")
+
+            class Reddit:
+                def __init__(self, *a, **k):
+                    pass
+
+                class Subreddit:
+                    def __init__(self, *a, **k):
+                        pass
+
+                    def search(self, *a, **k):
+                        return []
+
+                def subreddit(self, *a, **k):
+                    return Reddit.Subreddit()
+
+            praw_mod.Reddit = Reddit
+            module = praw_mod
         sys.modules[_missing] = module
 
 for _missing in ["litellm", "openai", "dspy", "dsp"]:
@@ -417,7 +786,11 @@ def mock_requests(monkeypatch):
         # Simulate a generic search response
         return DummyResponse({"webPages": {"value": []}, "hits": []}, "<html></html>")
 
-    monkeypatch.setattr("requests.get", fake_get)
+    def fake_post(*args, **kwargs):
+        return DummyResponse({}, "")
+
+    monkeypatch.setattr("requests.get", fake_get, raising=False)
+    monkeypatch.setattr("requests.post", fake_post, raising=False)
     return fake_get
 
 


### PR DESCRIPTION
## Summary
- expand test stubs to include numpy, snscrape, PIL, pytesseract, and praw
- import scrapers in VaultIngestHandler and store limits and credentials

## Testing
- `ruff check tests/conftest.py src/tino_storm/ingest/watcher.py`
- `black tests/conftest.py src/tino_storm/ingest/watcher.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68828f4f16888326aa66515761217aa5