### PR TITLE
Add CLI coverage for run and vault flags

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import pytest
 
 import knowledge_storm.storm_wiki.engine as ks_engine
 
@@ -66,3 +67,23 @@ def test_cli_research_creates_files(tmp_path, monkeypatch):
     assert (tmp_path / "storm_gen_article.txt").exists()
     assert (tmp_path / "run_config.json").exists()
     assert (tmp_path / "llm_call_history.jsonl").exists()
+
+
+def test_cli_run_unknown_subcommand(capsys):
+    """Invoking the missing 'run' command should exit with an error."""
+
+    with pytest.raises(SystemExit) as exc:
+        main(["run"])
+    out, err = capsys.readouterr()
+    assert "invalid choice" in err
+    assert exc.value.code == 2
+
+
+def test_cli_unknown_vault_option(capsys):
+    """Using the deprecated '--vault' option should raise a parse error."""
+
+    with pytest.raises(SystemExit) as exc:
+        main(["ingest", "--vault", "some"])
+    out, err = capsys.readouterr()
+    assert "unrecognized arguments" in err
+    assert exc.value.code == 2

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -78,6 +78,8 @@ def test_ingest_text_file(monkeypatch, tmp_path):
     event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
 
     monkeypatch.setattr("chromadb.PersistentClient", DummyClient)
+    # Ensure the watcher does not enable its test instrumentation
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
 
     vault_dir = tmp_path / "topic"
     vault_dir.mkdir()


### PR DESCRIPTION
## Summary
- add tests verifying `run` subcommand handling
- ensure unknown `--vault` option errors out
- protect watcher test from helper instrumentation
- check CLI error messages

## Testing
- `ruff check tests/test_cli.py tests/test_watcher.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882a3e9d308832681f45b8b725a9e52