### PR TITLE
Add run subcommand and vault support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,16 @@ which tino-storm
 
 ## Command line usage
 
-`tino-storm` provides a simple CLI.  The `research` sub-command runs a single
-pipeline and stores all outputs under the given directory.  The `serve`
-sub-command starts the API service.
+`tino-storm` provides a simple CLI.  The `run` sub-command executes a single
+pipeline and optionally ingests the generated article into a named vault.  The
+legacy `research` sub-command behaves the same without vault support.  The
+`serve` sub-command starts the API service.
 
 ```bash
 # Run a research task locally and save results under ./results
+$ tino-storm run --topic "Quantum computing" --output-dir ./results --vault demo
+
+# Legacy syntax
 $ tino-storm research "Quantum computing" --output-dir ./results
 
 # Start the API server

--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -27,6 +27,25 @@ def main(argv=None):
         "--skip-polish", action="store_true", help="Skip article polishing"
     )
 
+    run_p = subparsers.add_parser("run", help="Run a single research task")
+    run_p.add_argument("--topic", required=True, help="Topic to research")
+    run_p.add_argument("--vault", help="Vault to ingest results")
+    run_p.add_argument(
+        "--output-dir", default="./results", help="Directory for generated files"
+    )
+    run_p.add_argument(
+        "--skip-research", action="store_true", help="Skip information retrieval"
+    )
+    run_p.add_argument(
+        "--skip-outline", action="store_true", help="Skip outline generation"
+    )
+    run_p.add_argument(
+        "--skip-article", action="store_true", help="Skip article generation"
+    )
+    run_p.add_argument(
+        "--skip-polish", action="store_true", help="Skip article polishing"
+    )
+
     serve_p = subparsers.add_parser("serve", help="Launch API server")
     serve_p.add_argument("--host", default="0.0.0.0")
     serve_p.add_argument("--port", type=int, default=8000)
@@ -51,6 +70,16 @@ def main(argv=None):
         run_research(
             topic=args.topic,
             output_dir=args.output_dir,
+            do_research=not args.skip_research,
+            do_generate_outline=not args.skip_outline,
+            do_generate_article=not args.skip_article,
+            do_polish_article=not args.skip_polish,
+        )
+    elif args.command == "run":
+        run_research(
+            topic=args.topic,
+            output_dir=args.output_dir,
+            vault=args.vault,
             do_research=not args.skip_research,
             do_generate_outline=not args.skip_outline,
             do_generate_article=not args.skip_article,

--- a/src/tino_storm/ingest/watcher.py
+++ b/src/tino_storm/ingest/watcher.py
@@ -18,7 +18,6 @@ from ..security.encrypted_chroma import EncryptedChroma
 
 
 from ..events import ResearchAdded, event_emitter
-from ..ingestion import TwitterScraper, RedditScraper, FourChanScraper
 
 
 class VaultIngestHandler(FileSystemEventHandler):
@@ -35,11 +34,6 @@ class VaultIngestHandler(FileSystemEventHandler):
         reddit_client_secret: Optional[str] = None,
     ) -> None:
         self.root = Path(root).expanduser().resolve()
-        self.twitter_limit = twitter_limit
-        self.reddit_limit = reddit_limit
-        self.fourchan_limit = fourchan_limit
-        self.reddit_client_id = reddit_client_id
-        self.reddit_client_secret = reddit_client_secret
         chroma_root = Path(
             chroma_path
             or os.environ.get(
@@ -61,6 +55,8 @@ class VaultIngestHandler(FileSystemEventHandler):
                 col = cache.get(name)
                 if col is None:
                     col = orig_get(name, **kwargs)
+                    cache[name] = col
+                if not hasattr(col, "docs"):
                     col.docs = []
                     orig_add = col.add
 
@@ -76,11 +72,15 @@ class VaultIngestHandler(FileSystemEventHandler):
                         )
 
                     col.add = add
-                    cache[name] = col
                 return col
 
             self.client.get_or_create_collection = _get
 
+        self.twitter_limit = twitter_limit
+        self.reddit_limit = reddit_limit
+        self.fourchan_limit = fourchan_limit
+        self.reddit_client_id = reddit_client_id
+        self.reddit_client_secret = reddit_client_secret
 
         super().__init__()
 


### PR DESCRIPTION
## Summary
- add `run` CLI command with `--vault` option
- allow API `run_research` to ingest results into a vault
- document the new command
- restore watcher test hooks so ingestion tests work
- test new run CLI

## Testing
- `ruff check src/tino_storm/api.py src/tino_storm/cli.py tests/test_cli.py src/tino_storm/ingest/watcher.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882a3e9514c832687f632da47938677