### PR TITLE
Add ingest_path API function

### DIFF
--- a/src/tino_storm/ingest/__init__.py
+++ b/src/tino_storm/ingest/__init__.py
@@ -1,5 +1,39 @@
 """Utilities for ingesting external resources into Chroma collections."""
 
+from pathlib import Path
+from typing import Optional
+
 from .watcher import start_watcher, VaultIngestHandler
 
-__all__ = ["start_watcher", "VaultIngestHandler"]
+
+def ingest_path(
+    path: str,
+    vault: str,
+    *,
+    root: Optional[str] = None,
+    chroma_path: Optional[str] = None,
+    twitter_limit: Optional[int] = None,
+    reddit_limit: Optional[int] = None,
+    fourchan_limit: Optional[int] = None,
+    reddit_client_id: Optional[str] = None,
+    reddit_client_secret: Optional[str] = None,
+) -> None:
+    """Ingest a file or manifest into ``vault``.
+
+    Parameters mirror :class:`~VaultIngestHandler` so ingestion can be
+    triggered programmatically, e.g. from the ``/ingest`` API endpoint.
+    """
+
+    handler = VaultIngestHandler(
+        root or str(Path(path).expanduser().parent),
+        chroma_path=chroma_path,
+        twitter_limit=twitter_limit,
+        reddit_limit=reddit_limit,
+        fourchan_limit=fourchan_limit,
+        reddit_client_id=reddit_client_id,
+        reddit_client_secret=reddit_client_secret,
+    )
+    handler._handle_file(Path(path).expanduser(), vault)
+
+
+__all__ = ["start_watcher", "VaultIngestHandler", "ingest_path"]

--- a/tests/test_ingest_module.py
+++ b/tests/test_ingest_module.py
@@ -1,0 +1,28 @@
+import pathlib
+
+from tino_storm.ingest import ingest_path
+
+
+def test_ingest_path(monkeypatch, tmp_path):
+    calls = {}
+
+    class DummyHandler:
+        def __init__(self, root, **kwargs):
+            calls["root"] = root
+            calls["kwargs"] = kwargs
+
+        def _handle_file(self, path, vault):
+            calls["path"] = pathlib.Path(path)
+            calls["vault"] = vault
+
+    monkeypatch.setattr("tino_storm.ingest.VaultIngestHandler", DummyHandler)
+
+    file = tmp_path / "note.txt"
+    file.write_text("hello")
+
+    ingest_path(str(file), "topic", root=str(tmp_path), twitter_limit=1)
+
+    assert calls["root"] == str(tmp_path)
+    assert calls["kwargs"]["twitter_limit"] == 1
+    assert calls["path"] == file
+    assert calls["vault"] == "topic"


### PR DESCRIPTION
## Summary
- allow programmatic ingestion of a single file or manifest via `ingest_path`
- export new API from `tino_storm.ingest`
- test `ingest_path` wrapper

## Testing
- `ruff check src/tino_storm/ingest/__init__.py tests/test_ingest_module.py`
- `pytest tests/test_ingest_module.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c936e39083269c57746109fd8120