### PR TITLE
Add cross-vault search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ that produce JSON manifests.  Each item in a manifest should contain at least
 Drop such a `manifest.json` file inside your vault to have all entries ingested
 as individual documents.
 
+#### Cross-vault search
+
+Documents are stored in separate Chroma namespaces per vault.  Use
+`search_vaults()` to query multiple vaults at once and aggregate the results
+with Reciprocal Rank Fusion:
+
+```python
+from tino_storm.ingest import search_vaults
+
+results = search_vaults("machine learning", ["science", "notes"])
+```
+
 ### HTTP API
 
 When running `tino-storm serve` the following POST endpoints become available:

--- a/examples/cross_vault_search.py
+++ b/examples/cross_vault_search.py
@@ -1,0 +1,14 @@
+"""Example of searching across multiple STORM vaults."""
+
+from tino_storm.ingest import search_vaults
+
+
+def main() -> None:
+    results = search_vaults("climate change", ["science", "news"])
+    for item in results:
+        snippet = item.get("snippets", [""])[0]
+        print(f"{item['url']}: {snippet[:80]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tino_storm/ingest/__init__.py
+++ b/src/tino_storm/ingest/__init__.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Optional
 
 from .watcher import start_watcher, VaultIngestHandler
+from .search import search_vaults
 
 
 def ingest_path(
@@ -36,4 +37,4 @@ def ingest_path(
     handler._handle_file(Path(path).expanduser(), vault)
 
 
-__all__ = ["start_watcher", "VaultIngestHandler", "ingest_path"]
+__all__ = ["start_watcher", "VaultIngestHandler", "ingest_path", "search_vaults"]

--- a/src/tino_storm/ingest/search.py
+++ b/src/tino_storm/ingest/search.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Iterable, List, Dict, Optional
+
+import chromadb
+
+from ..security import get_passphrase
+from ..security.encrypted_chroma import EncryptedChroma
+from ..retrieval.rrf import reciprocal_rank_fusion
+
+
+def search_vaults(
+    query: str,
+    vaults: Iterable[str],
+    *,
+    k_per_vault: int = 5,
+    rrf_k: int = 60,
+    chroma_path: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Query multiple Chroma namespaces and combine results using RRF."""
+
+    chroma_root = Path(
+        chroma_path
+        or os.environ.get("STORM_CHROMA_PATH", Path.home() / ".tino_storm" / "chroma")
+    ).expanduser()
+
+    passphrase = get_passphrase()
+    if passphrase:
+        client = EncryptedChroma(str(chroma_root), passphrase=passphrase)
+    else:
+        client = chromadb.PersistentClient(path=str(chroma_root))
+
+    rankings: List[List[Dict[str, Any]]] = []
+    for vault in vaults:
+        collection = client.get_or_create_collection(vault)
+        try:
+            res = collection.query(query_texts=[query], n_results=k_per_vault)
+        except Exception:
+            res = {"documents": [[]], "metadatas": [[]]}
+
+        docs = res.get("documents", [[]])[0] or []
+        metas = res.get("metadatas", [[]])[0] or []
+
+        ranking: List[Dict[str, Any]] = []
+        for idx, doc in enumerate(docs):
+            meta = metas[idx] if idx < len(metas) else {}
+            url = meta.get("source", str(idx))
+            ranking.append({"url": url, "snippets": [doc]})
+        if ranking:
+            rankings.append(ranking)
+
+    if not rankings:
+        return []
+
+    return reciprocal_rank_fusion(rankings, k=rrf_k)


### PR DESCRIPTION
## Summary
- add `search_vaults` helper to query multiple Chroma namespaces
- expose new helper from `tino_storm.ingest`
- document cross-vault search in README
- provide an example script showing cross-vault usage

## Testing
- `black src/tino_storm/ingest/search.py src/tino_storm/ingest/__init__.py examples/cross_vault_search.py`
- `ruff check src/tino_storm/ingest/search.py src/tino_storm/ingest/__init__.py examples/cross_vault_search.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d4afebc883268014d11532376ca9