### PR TITLE
Apply RRF in retrieval

### DIFF
--- a/knowledge_storm/storm_wiki/modules/knowledge_curation.py
+++ b/knowledge_storm/storm_wiki/modules/knowledge_curation.py
@@ -9,8 +9,11 @@ import dspy
 from .callback import BaseCallbackHandler
 from .persona_generator import StormPersonaGenerator
 from .storm_dataclass import DialogueTurn, StormInformationTable
+from .retriever import is_valid_wikipedia_source
 from tino_storm.core.interface import KnowledgeCurationModule, Retriever, Information
 from tino_storm.core.utils import ArticleTextProcessing
+from tino_storm.retrieval import combine_ranks
+from difflib import SequenceMatcher
 
 try:
     from streamlit.runtime.scriptrunner import add_script_run_ctx
@@ -215,6 +218,21 @@ class TopicExpert(dspy.Module):
                 list(set(queries)), exclude_urls=[ground_truth_url]
             )
             if len(searched_results) > 0:
+                recency_ranking = searched_results
+                authority_ranking = sorted(
+                    searched_results,
+                    key=lambda r: 0 if is_valid_wikipedia_source(r.url) else 1,
+                )
+
+                def _sim(info):
+                    snippet = info.snippets[0] if info.snippets else ""
+                    return SequenceMatcher(None, question, snippet).ratio()
+
+                similarity_ranking = sorted(searched_results, key=_sim, reverse=True)
+
+                searched_results = combine_ranks(
+                    recency_ranking, authority_ranking, similarity_ranking
+                )
                 # Evaluate: Simplify this part by directly using the top 1 snippet.
                 info = ""
                 for n, r in enumerate(searched_results):

--- a/tests/test_rrf.py
+++ b/tests/test_rrf.py
@@ -1,0 +1,9 @@
+import tino_storm.retrieval as r
+
+
+def test_rrf_ordering():
+    recency = [{"url": "a"}, {"url": "b"}, {"url": "c"}]
+    authority = [{"url": "b"}, {"url": "a"}, {"url": "c"}]
+    similarity = [{"url": "a"}, {"url": "c"}, {"url": "b"}]
+    result = r.combine_ranks(recency, authority, similarity, k=60)
+    assert [d["url"] for d in result] == ["a", "b", "c"]


### PR DESCRIPTION
## Summary
- integrate reciprocal rank fusion in `TopicExpert` retrieval
- expose `combine_ranks` in both knowledge_storm and tino_storm modules
- unit test basic RRF behaviour

## Testing
- `ruff check knowledge_storm/storm_wiki/modules/knowledge_curation.py src/tino_storm/storm_wiki/modules/knowledge_curation.py tests/test_rrf.py`
- `black knowledge_storm/storm_wiki/modules/knowledge_curation.py src/tino_storm/storm_wiki/modules/knowledge_curation.py tests/test_rrf.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d4af5f588326923e319066fd84cd