### PR TITLE
Implement retrieval scoring

### DIFF
--- a/src/tino_storm/ingest/search.py
+++ b/src/tino_storm/ingest/search.py
@@ -9,6 +9,7 @@ import chromadb
 from ..security import get_passphrase
 from ..security.encrypted_chroma import EncryptedChroma
 from ..retrieval.rrf import reciprocal_rank_fusion
+from ..retrieval.scoring import score_results
 
 
 def search_vaults(
@@ -47,9 +48,9 @@ def search_vaults(
         for idx, doc in enumerate(docs):
             meta = metas[idx] if idx < len(metas) else {}
             url = meta.get("source", str(idx))
-            ranking.append({"url": url, "snippets": [doc]})
+            ranking.append({"url": url, "snippets": [doc], "meta": meta})
         if ranking:
-            rankings.append(ranking)
+            rankings.append(score_results(ranking))
 
     if not rankings:
         return []

--- a/src/tino_storm/retrieval/__init__.py
+++ b/src/tino_storm/retrieval/__init__.py
@@ -1,6 +1,7 @@
 """Utilities for advanced retrieval ranking."""
 
 from .rrf import reciprocal_rank_fusion
+from .scoring import compute_score, score_results
 from typing import List, Dict, Any
 
 
@@ -16,4 +17,4 @@ def combine_ranks(
     )
 
 
-__all__ = ["reciprocal_rank_fusion", "combine_ranks"]
+__all__ = ["reciprocal_rank_fusion", "combine_ranks", "compute_score", "score_results"]

--- a/src/tino_storm/retrieval/scoring.py
+++ b/src/tino_storm/retrieval/scoring.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+
+def compute_score(info: Dict[str, Any]) -> float:
+    """Return a numeric score for a search result.
+
+    The score combines recency, citation/karma and model confidence.
+    ``info`` may contain a ``meta`` dictionary where these values are stored.
+    """
+    meta = info.get("meta", info)
+
+    # recency score based on days since timestamp/date
+    recency_score = 0.0
+    date_val = meta.get("date") or meta.get("timestamp")
+    if date_val:
+        try:
+            dt = date_val
+            if not isinstance(dt, datetime):
+                dt = datetime.fromisoformat(str(dt))
+            dt = dt.replace(tzinfo=dt.tzinfo or timezone.utc)
+            age_days = (datetime.now(timezone.utc) - dt).total_seconds() / 86400
+            recency_score = 1.0 / (1.0 + max(age_days, 0.0))
+        except Exception:
+            recency_score = 0.0
+
+    # citation/karma score
+    citation_score = float(meta.get("citations", meta.get("karma", 0)) or 0)
+
+    # model confidence score
+    confidence_score = float(
+        meta.get("confidence", meta.get("model_confidence", 0)) or 0
+    )
+
+    return recency_score + citation_score + confidence_score
+
+
+def score_results(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Compute scores for ``results`` and return them sorted by score."""
+    scored = []
+    for r in results:
+        info = dict(r)
+        info["score"] = compute_score(info)
+        scored.append(info)
+    return sorted(scored, key=lambda x: x["score"], reverse=True)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,25 @@
+import tino_storm.retrieval as r
+from datetime import datetime, timedelta, timezone
+
+
+def test_compute_score_recency():
+    now = datetime.now(timezone.utc)
+    recent = {"meta": {"date": now.isoformat()}}
+    older = {"meta": {"date": (now - timedelta(days=10)).isoformat()}}
+    assert r.compute_score(recent) > r.compute_score(older)
+
+
+def test_compute_score_citation_and_confidence():
+    base = {"meta": {"citations": 1}}
+    confident = {"meta": {"citations": 1, "confidence": 1}}
+    assert r.compute_score(confident) > r.compute_score(base)
+
+
+def test_score_results_sorting():
+    now = datetime.now(timezone.utc)
+    docs = [
+        {"url": "a", "meta": {"date": now.isoformat(), "citations": 1}},
+        {"url": "b", "meta": {"date": (now - timedelta(days=5)).isoformat()}},
+    ]
+    ranked = r.score_results(docs)
+    assert ranked[0]["url"] == "a"


### PR DESCRIPTION
## Summary
- score retrieval results by recency, karma and model confidence
- sort vault search results using the new scoring
- export scoring helpers from retrieval package
- test scoring utilities

## Testing
- `black src/tino_storm/retrieval/scoring.py src/tino_storm/retrieval/__init__.py src/tino_storm/ingest/search.py tests/test_scoring.py`
- `ruff check src/tino_storm/retrieval/scoring.py src/tino_storm/retrieval/__init__.py src/tino_storm/ingest/search.py tests/test_scoring.py`
- `pytest tests/test_scoring.py tests/test_rrf.py`

------
https://chatgpt.com/codex/tasks/task_e_6882e2fb6970832692cb33b1ecfdc28b