### PR TITLE
Add search subparser to CLI

### DIFF
--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -2,7 +2,7 @@ import argparse
 import uvicorn
 
 from .api import app, run_research
-from .ingest import start_watcher
+from .ingest import search_vaults, start_watcher
 
 
 def main(argv=None):
@@ -64,6 +64,10 @@ def main(argv=None):
     ingest_p.add_argument("--reddit-client-id")
     ingest_p.add_argument("--reddit-client-secret")
 
+    search_p = subparsers.add_parser("search", help="Search across vaults")
+    search_p.add_argument("query", help="Query string")
+    search_p.add_argument("vaults", help="Comma-separated list of vaults to search")
+
     args = parser.parse_args(argv)
 
     if args.command == "research":
@@ -96,6 +100,12 @@ def main(argv=None):
             reddit_client_id=args.reddit_client_id,
             reddit_client_secret=args.reddit_client_secret,
         )
+    elif args.command == "search":
+        vaults = [v.strip() for v in args.vaults.split(",") if v.strip()]
+        results = search_vaults(args.query, vaults)
+        for item in results:
+            snippet = item.get("snippets", [""])[0]
+            print(f"{item['url']}: {snippet[:80]}")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,3 +112,18 @@ def test_cli_run_with_vault(tmp_path, monkeypatch):
     assert (tmp_path / "storm_gen_article.txt").exists()
     assert (tmp_path / "run_config.json").exists()
     assert (tmp_path / "llm_call_history.jsonl").exists()
+
+
+def test_cli_search(monkeypatch, capsys):
+    """Search sub-command should print URL and snippet."""
+
+    def dummy_search(query, vaults):
+        assert query == "q"
+        assert vaults == ["v1", "v2"]
+        return [{"url": "u", "snippets": ["result text"]}]
+
+    monkeypatch.setattr("tino_storm.cli.search_vaults", dummy_search)
+
+    main(["search", "q", "v1,v2"])
+    output = capsys.readouterr().out
+    assert "u: result text" in output


### PR DESCRIPTION
## Summary
- add `search` command to CLI
- dispatch to `tino_storm.ingest.search_vaults`
- print results in CLI search output
- add unit test for search command

## Testing
- `pre-commit run --files src/tino_storm/cli.py tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6882ef1e78648326b9d50073edc97e1e