### PR TITLE
Expose RM module under knowledge_storm

### DIFF
--- a/knowledge_storm/__init__.py
+++ b/knowledge_storm/__init__.py
@@ -5,7 +5,7 @@ eagerly importing heavy dependencies when the package is imported.
 Submodules should be imported explicitly by consumers as needed.
 """
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "rm"]
 
 # importing these modules here previously pulled in numerous optional
 # dependencies during test discovery. To keep startup lightweight we no

--- a/knowledge_storm/rm.py
+++ b/knowledge_storm/rm.py
@@ -1,0 +1,1 @@
+from tino_storm.core.rm import *  # noqa: F401,F403

--- a/tests/test_bing_search_import.py
+++ b/tests/test_bing_search_import.py
@@ -1,0 +1,5 @@
+from knowledge_storm.rm import BingSearch
+
+
+def test_bing_search_import_available():
+    assert BingSearch is not None


### PR DESCRIPTION
## Summary
- export retrievers from `tino_storm.core.rm` via new `knowledge_storm.rm`
- include `rm` in the `knowledge_storm.__all__` list
- regression test that `knowledge_storm.rm.BingSearch` is importable

## Testing
- `pre-commit run --files knowledge_storm/__init__.py knowledge_storm/rm.py tests/test_bing_search_import.py src/tino_storm/api.py` *(fails: files were modified by this hook)*
- `pre-commit run --files knowledge_storm/__init__.py knowledge_storm/rm.py tests/test_bing_search_import.py src/tino_storm/api.py` *(fails: files were modified by this hook)*
- `pytest tests/test_bing_search_import.py`

------
https://chatgpt.com/codex/tasks/task_e_6883d22f6a448326829644ef8927302c