### PR TITLE
Add arXiv ingestion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ that produce JSON manifests.  Each item in a manifest should contain at least
 Drop such a `manifest.json` file inside your vault to have all entries ingested
 as individual documents.
 
+An `.arxiv` file with one identifier per line downloads each paper's metadata
+and PDF text for ingestion.
+
 #### Cross-vault search
 
 Documents are stored in separate Chroma namespaces per vault.  Use

--- a/src/tino_storm/ingestion/__init__.py
+++ b/src/tino_storm/ingestion/__init__.py
@@ -1,6 +1,13 @@
 from .twitter import TwitterScraper
 from .reddit import RedditScraper
 from .fourchan import FourChanScraper
+from .arxiv import ArxivScraper
 from .utils import ocr_image
 
-__all__ = ["TwitterScraper", "RedditScraper", "FourChanScraper", "ocr_image"]
+__all__ = [
+    "TwitterScraper",
+    "RedditScraper",
+    "FourChanScraper",
+    "ArxivScraper",
+    "ocr_image",
+]

--- a/src/tino_storm/ingestion/arxiv.py
+++ b/src/tino_storm/ingestion/arxiv.py
@@ -1,0 +1,74 @@
+"""Simple helper to fetch arXiv papers."""
+
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from typing import Dict, List
+
+import requests
+
+from ..security import log_request
+
+try:  # optional dependency
+    import arxiv  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    arxiv = None  # type: ignore
+
+try:
+    from pypdf import PdfReader  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    try:
+        from PyPDF2 import PdfReader  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        PdfReader = None  # type: ignore
+
+
+class ArxivScraper:
+    """Fetch paper metadata and PDF text from arXiv."""
+
+    def _pdf_text(self, url: str) -> str:
+        if PdfReader is None:
+            return ""
+        try:
+            log_request("GET", url)
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            reader = PdfReader(BytesIO(resp.content))
+            return "\n".join(page.extract_text() or "" for page in reader.pages).strip()
+        except Exception:
+            return ""
+
+    def fetch(self, arxiv_id: str) -> Dict[str, str]:
+        global arxiv
+        if not callable(getattr(arxiv, "Search", None)):
+            try:
+                import arxiv as arxiv_mod  # type: ignore
+
+                arxiv = arxiv_mod
+            except Exception as exc:  # pragma: no cover - optional dependency
+                raise RuntimeError(
+                    "arxiv package is required for Arxiv scraping"
+                ) from exc
+
+        client = arxiv.Client()
+        search = arxiv.Search(id_list=[arxiv_id])
+        result = next(client.results(search), None)
+        if result is None:
+            raise ValueError(f"Paper {arxiv_id} not found")
+        pdf_text = (
+            self._pdf_text(result.pdf_url) if getattr(result, "pdf_url", None) else ""
+        )
+        return {
+            "id": arxiv_id,
+            "title": getattr(result, "title", ""),
+            "summary": getattr(result, "summary", ""),
+            "url": getattr(result, "entry_id", ""),
+            "pdf_text": pdf_text,
+        }
+
+    def fetch_many(self, ids: List[str]) -> List[Dict[str, str]]:
+        return [self.fetch(i) for i in ids]
+
+    def dump_json(self, ids: List[str]) -> str:
+        return json.dumps(self.fetch_many(ids))

--- a/tests/test_arxiv_ingestion.py
+++ b/tests/test_arxiv_ingestion.py
@@ -1,0 +1,87 @@
+# ruff: noqa: E402
+import os
+import sys
+import types
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+# Stub arxiv if missing
+if "arxiv" not in sys.modules:
+    arxiv = types.ModuleType("arxiv")
+
+    class Search:
+        def __init__(self, *a, **k):
+            pass
+
+    class Result:
+        def __init__(self):
+            self.entry_id = "http://arxiv.org/abs/1234"
+            self.title = "title"
+            self.summary = "summary"
+            self.pdf_url = "http://example.com/paper.pdf"
+
+    class Client:
+        def __init__(self, *a, **k):
+            pass
+
+        def results(self, *_a, **_k):
+            yield Result()
+
+    arxiv.Search = Search
+    arxiv.Client = Client
+    sys.modules["arxiv"] = arxiv
+
+# Stub PdfReader
+if "pypdf" not in sys.modules:
+    pypdf = types.ModuleType("pypdf")
+
+    class DummyReader:
+        def __init__(self, *a, **k):
+            self.pages = [types.SimpleNamespace(extract_text=lambda: "pdf text")]
+
+    pypdf.PdfReader = DummyReader
+    sys.modules["pypdf"] = pypdf
+    sys.modules.setdefault("PyPDF2", pypdf)
+
+from tino_storm.ingestion import ArxivScraper  # noqa: E402
+from tino_storm.ingest.watcher import VaultIngestHandler  # noqa: E402
+
+
+def test_arxiv_scraper(monkeypatch):
+    def fake_get(*a, **k):
+        return types.SimpleNamespace(content=b"data", raise_for_status=lambda: None)
+
+    monkeypatch.setattr("requests.get", fake_get, raising=False)
+    scraper = ArxivScraper()
+    res = scraper.fetch("1234")
+    assert res["pdf_text"] == "pdf text"
+    assert res["title"] == "title"
+
+
+class DummyScraper:
+    def __init__(self, results):
+        self._results = results
+
+    def fetch_many(self, ids):
+        return self._results
+
+
+def test_handle_arxiv(monkeypatch, tmp_path):
+    res = [{"title": "t", "summary": "s", "pdf_text": "p", "url": "u"}]
+    root = tmp_path / "vault"
+    vault = root / "topic"
+    vault.mkdir(parents=True)
+    file = vault / "ids.arxiv"
+    file.write_text("1234\n")
+    handler = VaultIngestHandler(str(root))
+    captured = []
+    monkeypatch.setattr(
+        handler, "_ingest_text", lambda t, s, v: captured.append((t, s, v))
+    )
+    monkeypatch.setattr(
+        "tino_storm.ingest.watcher.ArxivScraper", lambda *a, **k: DummyScraper(res)
+    )
+    handler._handle_file(file, "topic")
+    assert captured and captured[0][0].startswith("t")


### PR DESCRIPTION
## Summary
- add an `ArxivScraper` loader
- export `ArxivScraper` in ingestion package
- allow `.arxiv` manifests in `VaultIngestHandler`
- document Arxiv support
- add unit tests for Arxiv ingestion

## Testing
- `pre-commit run --files src/tino_storm/ingestion/arxiv.py src/tino_storm/ingestion/__init__.py src/tino_storm/ingest/watcher.py README.md tests/test_arxiv_ingestion.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e4549990832699df90531c2b195e