### PR TITLE
Add Bayesian posterior scoring to retrieval

### DIFF
--- a/src/tino_storm/ingest/search.py
+++ b/src/tino_storm/ingest/search.py
@@ -16,6 +16,7 @@ from ..security import (
 from ..security.encrypted_chroma import EncryptedChroma
 from ..retrieval.rrf import reciprocal_rank_fusion
 from ..retrieval.scoring import score_results
+from ..retrieval.bayes import add_posteriors
 
 
 def search_vaults(
@@ -64,4 +65,5 @@ def search_vaults(
     if not rankings:
         return []
 
-    return reciprocal_rank_fusion(rankings, k=rrf_k)
+    fused = reciprocal_rank_fusion(rankings, k=rrf_k)
+    return add_posteriors(fused)

--- a/src/tino_storm/retrieval/__init__.py
+++ b/src/tino_storm/retrieval/__init__.py
@@ -2,6 +2,7 @@
 
 from .rrf import reciprocal_rank_fusion
 from .scoring import compute_score, score_results
+from .bayes import update_posterior, add_posteriors
 from typing import List, Dict, Any
 
 
@@ -17,4 +18,11 @@ def combine_ranks(
     )
 
 
-__all__ = ["reciprocal_rank_fusion", "combine_ranks", "compute_score", "score_results"]
+__all__ = [
+    "reciprocal_rank_fusion",
+    "combine_ranks",
+    "compute_score",
+    "score_results",
+    "update_posterior",
+    "add_posteriors",
+]

--- a/src/tino_storm/retrieval/bayes.py
+++ b/src/tino_storm/retrieval/bayes.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+
+def update_posterior(info: Dict[str, Any], prior: float = 0.5) -> float:
+    """Return an updated posterior score based on recency and citations."""
+    meta = info.get("meta", info)
+
+    recency_factor = 1.0
+    date_val = meta.get("date") or meta.get("timestamp")
+    if date_val:
+        try:
+            dt = date_val
+            if not isinstance(dt, datetime):
+                dt = datetime.fromisoformat(str(dt))
+            dt = dt.replace(tzinfo=dt.tzinfo or timezone.utc)
+            age_days = (datetime.now(timezone.utc) - dt).total_seconds() / 86400
+            recency_factor = 1.0 / (1.0 + max(age_days, 0.0))
+        except Exception:
+            recency_factor = 1.0
+
+    citation_factor = 1.0 + float(meta.get("citations", meta.get("karma", 0)) or 0)
+
+    return prior * recency_factor * citation_factor
+
+
+def add_posteriors(
+    results: List[Dict[str, Any]], prior: float = 0.5
+) -> List[Dict[str, Any]]:
+    """Attach posterior scores to a list of result dictionaries."""
+    updated = []
+    for r in results:
+        info = dict(r)
+        info["posterior"] = update_posterior(info, prior)
+        updated.append(info)
+    return updated

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -1,0 +1,16 @@
+import tino_storm.retrieval as r
+from datetime import datetime, timedelta, timezone
+
+
+def test_posterior_decreases_with_age():
+    now = datetime.now(timezone.utc)
+    recent = {"meta": {"date": now.isoformat(), "citations": 0}}
+    old = {"meta": {"date": (now - timedelta(days=5)).isoformat(), "citations": 0}}
+    assert r.update_posterior(recent, prior=0.5) > r.update_posterior(old, prior=0.5)
+
+
+def test_posterior_increases_with_citations():
+    now = datetime.now(timezone.utc)
+    low = {"meta": {"date": now.isoformat(), "citations": 1}}
+    high = {"meta": {"date": now.isoformat(), "citations": 5}}
+    assert r.update_posterior(high, prior=0.5) > r.update_posterior(low, prior=0.5)


### PR DESCRIPTION
## Summary
- add bayesian module implementing posterior scoring from recency and citations
- export posterior helpers in retrieval package
- include posterior scores in `search_vaults` results
- test posterior update logic

## Testing
- `ruff check src/tino_storm/retrieval/bayes.py src/tino_storm/retrieval/__init__.py src/tino_storm/ingest/search.py tests/test_bayes.py`
- `pytest tests/test_bayes.py tests/test_search_vaults.py::test_search_vaults_rrf`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6883f15e52ec8326a91e058c782f3903