### PR TITLE
Add web crawler ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ as individual documents.
 An `.arxiv` file with one identifier per line downloads each paper's metadata
 and PDF text for ingestion.
 
+A `.web` file should contain a JSON array of URLs. Each listed page will be
+fetched and the extracted text ingested as a separate document.
+
 #### Cross-vault search
 
 Documents are stored in separate Chroma namespaces per vault.  Use

--- a/src/tino_storm/ingestion/__init__.py
+++ b/src/tino_storm/ingestion/__init__.py
@@ -2,6 +2,7 @@ from .twitter import TwitterScraper
 from .reddit import RedditScraper
 from .fourchan import FourChanScraper
 from .arxiv import ArxivScraper
+from .crawler import WebCrawler
 from .utils import ocr_image
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     "RedditScraper",
     "FourChanScraper",
     "ArxivScraper",
+    "WebCrawler",
     "ocr_image",
 ]

--- a/src/tino_storm/ingestion/crawler.py
+++ b/src/tino_storm/ingestion/crawler.py
@@ -1,0 +1,29 @@
+import json
+from typing import Dict, List
+
+import requests
+import trafilatura
+
+from ..security import log_request
+
+
+class WebCrawler:
+    """Fetch web pages and extract text with ``trafilatura``."""
+
+    def fetch(self, url: str) -> Dict[str, str]:
+        """Return a dictionary containing ``url`` and extracted ``text``."""
+        try:
+            log_request("GET", url)
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            html = resp.text
+        except Exception:
+            html = ""
+        text = trafilatura.extract(html) or ""
+        return {"url": url, "text": text}
+
+    def fetch_many(self, urls: List[str]) -> List[Dict[str, str]]:
+        return [self.fetch(u) for u in urls]
+
+    def dump_json(self, urls: List[str]) -> str:
+        return json.dumps(self.fetch_many(urls))


### PR DESCRIPTION
## Summary
- support crawling web pages via new `WebCrawler`
- import and use `WebCrawler` in `VaultIngestHandler`
- recognize `.web` manifests listing URLs for crawling
- document `.web` files in README
- test `.web` ingestion logic

## Testing
- `black src/tino_storm/ingest/watcher.py src/tino_storm/ingestion/__init__.py src/tino_storm/ingestion/crawler.py tests/test_vault_ingest_handler.py`
- `ruff check src/tino_storm/ingest/watcher.py src/tino_storm/ingestion/__init__.py src/tino_storm/ingestion/crawler.py tests/test_vault_ingest_handler.py`
- `pytest -q tests/test_vault_ingest_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_6886e2e62188832685d7b77ae32f2f62