### PR TITLE
Update install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,19 @@ split into two Python packages shipped from this repository:
 - **`tino-storm`** – a lightweight wrapper exposing a command line interface and
   a small FastAPI service.
 
-Install both with:
+Install the CLI and underlying library from PyPI:
 
 ```bash
-pip install tino-storm  # installs knowledge-storm and all dependencies
-# verify the console script was installed
-tino-storm --help
-
+pip install tino-storm
 ```
 
-The package depends on `httpx`, `requests`, `PyYAML`, `cryptography`,
-`fastapi` and `uvicorn`. These are installed automatically.
+This command installs both the `tino-storm` wrapper and the
+`knowledge-storm` package, along with all required dependencies.  Verify
+the console script was installed with:
+
+```bash
+tino-storm --help
+```
 
 For development, install in editable mode to register the `tino-storm` command:
 

--- a/frontend/demo_light/README.md
+++ b/frontend/demo_light/README.md
@@ -15,7 +15,7 @@ This is a minimal user interface for `STORMWikiRunner` which includes the follow
 </p>
 
 ## Setup
-1. Make sure you have installed `knowledge-storm` or set up the source code correctly.
+1. Install `tino-storm` (which includes the `knowledge-storm` library) or set up the source code correctly.
 2. Install additional packages required by the user interface:
     ```bash
     pip install -r requirements.txt

--- a/frontend/demo_light/demo_util.py
+++ b/frontend/demo_light/demo_util.py
@@ -9,7 +9,7 @@ import markdown
 import pytz
 import streamlit as st
 
-# If you install the source code instead of the `knowledge-storm` package,
+# If you are running from source instead of the installed `tino-storm` package,
 # Uncomment the following lines:
 # import sys
 # sys.path.append('../../')


### PR DESCRIPTION
## Summary
- clarify that `pip install tino-storm` also installs `knowledge-storm`
- update demo instructions about installation
- tweak demo comment for running from source

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68878475949083269e660e173e0c5f43