### PR TITLE
Document ingestion folder layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ files ending in `.url`/`.urls` are parsed and the contents stored in a local
 Chroma collection under `~/.tino_storm/chroma` (override with
 `STORM_CHROMA_PATH`). The vault root defaults to `./research` but can be
 customised with `--root` or the `STORM_VAULT_ROOT` environment variable.
+The expected folder layout and list of supported manifest types are documented
+in [docs/ingest.md](docs/ingest.md).
 
 #### Social manifests
 

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -1,0 +1,30 @@
+# Ingestion folder layout
+
+`tino-storm ingest` monitors a directory for dropped files. The specified `--root` acts as the vault root where each first level subdirectory becomes a vault name.
+
+Example structure:
+
+```text
+vault-root/
+  science/
+    notes.txt
+    links.urls
+  news/
+    manifest.web
+    papers.arxiv
+```
+
+Dropped files are routed to the vault named after their immediate parent directory and stored in a Chroma database under `~/.tino_storm/chroma` (change with `STORM_CHROMA_PATH`).
+
+## Supported manifest types
+
+The watcher recognises several file extensions and processes them via the ingestion scrapers:
+
+- `.url` or `.urls` – newline separated list of URLs
+- `.web` – JSON array of URLs crawled by [`crawler.py`](../src/tino_storm/ingestion/crawler.py)
+- `.twitter` – search query handled by [`twitter.py`](../src/tino_storm/ingestion/twitter.py)
+- `.reddit` – first line subreddit, optional second line query, scraped by [`reddit.py`](../src/tino_storm/ingestion/reddit.py)
+- `.arxiv` – one arXiv identifier per line fetched by [`arxiv.py`](../src/tino_storm/ingestion/arxiv.py)
+- `.4chan` – board name and thread number ingested via [`fourchan.py`](../src/tino_storm/ingestion/fourchan.py)
+
+Any other text file is added to the vault verbatim.


### PR DESCRIPTION
## Summary
- document watcher root folder structure and manifest formats
- point README to the new doc

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688790d326d08326a2255e9d6348d465