### PR TITLE
Add search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,13 @@ When running `tino-storm serve` the following POST endpoints become available:
 - `/outline` – run just the research and outline steps.
 - `/draft` – generate a draft article without the polishing stage.
 - `/ingest` – store arbitrary text in a named vault.
+- `/search` – query multiple vaults and fuse the results.
 
 The first three endpoints accept a JSON body with `topic`, optional
 `output_dir` and `vault` fields.  The `/ingest` endpoint expects `text`,
-`vault` and an optional `source` identifying the origin of the text.
+`vault` and an optional `source` identifying the origin of the text.  The
+`/search` endpoint expects `query`, a list of `vaults` and optional
+`k_per_vault` and `rrf_k` parameters.
 
 ## Programmatic API
 


### PR DESCRIPTION
## Summary
- expose new `/search` POST endpoint in FastAPI server
- document query endpoint in the README
- test search endpoint in API tests

## Testing
- `pre-commit run --files src/tino_storm/api.py tests/test_api_endpoints.py README.md`

------
https://chatgpt.com/codex/tasks/task_e_688799b925988326b617575c047fd0d8