### PR TITLE
Handle .txt files via SimpleDirectoryReader

### DIFF
--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -26,5 +26,7 @@ The watcher recognises several file extensions and processes them via the ingest
 - `.reddit` – first line subreddit, optional second line query, scraped by [`reddit.py`](../src/tino_storm/ingestion/reddit.py)
 - `.arxiv` – one arXiv identifier per line fetched by [`arxiv.py`](../src/tino_storm/ingestion/arxiv.py)
 - `.4chan` – board name and thread number ingested via [`fourchan.py`](../src/tino_storm/ingestion/fourchan.py)
+- `.txt` files are parsed with `llama_index.SimpleDirectoryReader` and each
+  resulting document is ingested individually.
 
 Any other text file is added to the vault verbatim.

--- a/src/tino_storm/ingest/__init__.py
+++ b/src/tino_storm/ingest/__init__.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Optional
 
-from .watcher import start_watcher, VaultIngestHandler
+from .watcher import start_watcher, VaultIngestHandler, load_txt_documents
 from .search import search_vaults
 
 
@@ -38,4 +38,10 @@ def ingest_path(
     handler._handle_file(Path(path).expanduser(), vault)
 
 
-__all__ = ["start_watcher", "VaultIngestHandler", "ingest_path", "search_vaults"]
+__all__ = [
+    "start_watcher",
+    "VaultIngestHandler",
+    "ingest_path",
+    "search_vaults",
+    "load_txt_documents",
+]


### PR DESCRIPTION
## Summary
- ingest `.txt` files by parsing them with `llama_index.SimpleDirectoryReader`
- expose `load_txt_documents` helper
- mock `SimpleDirectoryReader` in watcher tests
- document `.txt` ingestion

## Testing
- `ruff check src/tino_storm/ingest/watcher.py src/tino_storm/ingest/__init__.py tests/test_watcher.py`
- `pytest tests/test_watcher.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68879fb626d08326a0ffa84ae83ba859