### PR TITLE
Update ResearchSkill remote LM logic

### DIFF
--- a/src/tino_storm/core/utils.py
+++ b/src/tino_storm/core/utils.py
@@ -173,7 +173,14 @@ class QdrantVectorStoreManager:
         embedding_model: str = "BAAI/bge-m3",
         device: str = "mps",
     ):
-        from langchain_core.documents import Document
+        try:
+            from langchain_core.documents import Document
+        except Exception:  # pragma: no cover - fallback for tests without langchain
+
+            class Document:
+                def __init__(self, page_content, metadata):
+                    self.page_content = page_content
+                    self.metadata = metadata
 
         """
         Takes a CSV file and adds each row in the CSV file to the Qdrant collection.

--- a/src/tino_storm/skills/research.py
+++ b/src/tino_storm/skills/research.py
@@ -107,7 +107,10 @@ class ResearchSkill:
 
         self.cloud_allowed = cloud_allowed
         if cloud_allowed:
-            lm = _DummyLM()
+            try:
+                lm = dspy.LM("gpt-3.5-turbo")
+            except Exception:
+                lm = _DummyLM()
         else:
             try:
                 lm = dspy.HFModel("google/flan-t5-small")

--- a/tests/test_research_skill.py
+++ b/tests/test_research_skill.py
@@ -69,3 +69,21 @@ def test_research_skill(monkeypatch):
     )
     assert isinstance(table, StormInformationTable)
     assert "u" in table.url_to_info
+
+
+def test_cloud_allowed_uses_remote_lm(monkeypatch):
+    import tino_storm.skills.research as research
+
+    captured = {}
+
+    class DummyLM:
+        def __init__(self, model, *a, **k):
+            captured["model"] = model
+
+    monkeypatch.setattr(research.dspy, "LM", DummyLM)
+
+    skill = research.ResearchSkill(cloud_allowed=True)
+
+    assert isinstance(skill.outline.engine, DummyLM)
+    assert captured["model"] == "gpt-3.5-turbo"
+    assert not isinstance(skill.outline.engine, research._DummyLM)


### PR DESCRIPTION
## Summary
- use a real remote LM when cloud access is allowed
- fallback to `_DummyLM` if remote LM creation fails
- ensure `langchain_core` is optional in utils
- test remote LM selection when `cloud_allowed=True`

## Testing
- `pre-commit run --files src/tino_storm/skills/research.py tests/test_research_skill.py src/tino_storm/core/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c6821c3883269b0d879c4bd6d1c1