### PR TITLE
Add async search wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ from tino_storm.ingest import search_vaults
 results = search_vaults("machine learning", ["science", "news", "notes"])
 ```
 
+```python
+import tino_storm
+
+# async usage
+results = await tino_storm.search("machine learning", ["science"])
+```
+
 ### HTTP API
 
 When running `tino-storm serve` the following POST endpoints become available:

--- a/src/tino_storm/__init__.py
+++ b/src/tino_storm/__init__.py
@@ -14,6 +14,8 @@ __all__ = [
     "RunnerArgument",
     "CoStormRunner",
     "ResearchSkill",
+    "search",
+    "search_async",
 ]
 
 __version__ = "1.2.0"
@@ -32,6 +34,8 @@ _ATTR_MAP = {
     "RunnerArgument": ("tino_storm.collaborative_storm.engine", "RunnerArgument"),
     "CoStormRunner": ("tino_storm.collaborative_storm.engine", "CoStormRunner"),
     "ResearchSkill": ("tino_storm.skills", "ResearchSkill"),
+    "search": ("tino_storm.search", "search"),
+    "search_async": ("tino_storm.search", "search_async"),
 }
 
 

--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -1,0 +1,59 @@
+import asyncio
+from typing import Iterable, List, Dict, Any, Optional
+
+from .ingest import search_vaults
+
+
+async def search_async(
+    query: str,
+    vaults: Iterable[str],
+    *,
+    k_per_vault: int = 5,
+    rrf_k: int = 60,
+    chroma_path: Optional[str] = None,
+    vault: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Asynchronously query ``vaults`` using :func:`search_vaults` in a thread."""
+
+    return await asyncio.to_thread(
+        search_vaults,
+        query,
+        vaults,
+        k_per_vault=k_per_vault,
+        rrf_k=rrf_k,
+        chroma_path=chroma_path,
+        vault=vault,
+    )
+
+
+def search(
+    query: str,
+    vaults: Iterable[str],
+    *,
+    k_per_vault: int = 5,
+    rrf_k: int = 60,
+    chroma_path: Optional[str] = None,
+    vault: Optional[str] = None,
+):
+    """Query ``vaults`` synchronously or return an awaitable when in an event loop."""
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return search_vaults(
+            query,
+            vaults,
+            k_per_vault=k_per_vault,
+            rrf_k=rrf_k,
+            chroma_path=chroma_path,
+            vault=vault,
+        )
+
+    return search_async(
+        query,
+        vaults,
+        k_per_vault=k_per_vault,
+        rrf_k=rrf_k,
+        chroma_path=chroma_path,
+        vault=vault,
+    )

--- a/tests/test_search_function.py
+++ b/tests/test_search_function.py
@@ -1,0 +1,58 @@
+import asyncio
+import importlib
+
+import tino_storm
+
+
+def test_search_sync(monkeypatch):
+    """search() should call search_vaults when no event loop is running."""
+
+    called = {}
+
+    def fake_search_vaults(
+        query, vaults, *, k_per_vault=5, rrf_k=60, chroma_path=None, vault=None
+    ):
+        called["args"] = (query, list(vaults), k_per_vault, rrf_k, chroma_path, vault)
+        return ["ok"]
+
+    search_mod = importlib.import_module("tino_storm.search")
+    monkeypatch.setattr(search_mod, "search_vaults", fake_search_vaults)
+    # restore attribute pointing to function after importing module
+    tino_storm.search = search_mod.search
+    tino_storm.search_async = search_mod.search_async
+
+    result = tino_storm.search("q", ["v"])
+
+    assert result == ["ok"]
+    assert called["args"] == ("q", ["v"], 5, 60, None, None)
+
+
+def test_search_async(monkeypatch):
+    """search() should delegate to asyncio.to_thread inside an event loop."""
+
+    called = {}
+
+    async def fake_to_thread(func, *a, **k):
+        called["thread"] = True
+        return func(*a, **k)
+
+    def fake_search_vaults(
+        query, vaults, *, k_per_vault=5, rrf_k=60, chroma_path=None, vault=None
+    ):
+        called["args"] = (query, list(vaults), k_per_vault, rrf_k, chroma_path, vault)
+        return ["async"]
+
+    search_mod = importlib.import_module("tino_storm.search")
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(search_mod, "search_vaults", fake_search_vaults)
+    tino_storm.search = search_mod.search
+    tino_storm.search_async = search_mod.search_async
+
+    async def _run():
+        return await tino_storm.search("q", ["v"])
+
+    result = asyncio.run(_run())
+
+    assert result == ["async"]
+    assert called["thread"]
+    assert called["args"] == ("q", ["v"], 5, 60, None, None)


### PR DESCRIPTION
## Summary
- expose search and search_async APIs on package root
- implement new async search helper using asyncio.to_thread
- document async search usage in README
- test sync and async search behaviours

## Testing
- `pre-commit run --files src/tino_storm/search.py src/tino_storm/__init__.py README.md tests/test_search_function.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c681dca88326ae565d401ff4060a