### PR TITLE
Switch CLI and API search to async wrapper

### DIFF
--- a/src/tino_storm/api.py
+++ b/src/tino_storm/api.py
@@ -11,11 +11,7 @@ from knowledge_storm import (
 from knowledge_storm.lm import LitellmModel
 from knowledge_storm.rm import BingSearch
 
-
-def search_vaults(*args, **kwargs):
-    from .ingest.search import search_vaults as _search_vaults
-
-    return _search_vaults(*args, **kwargs)
+from . import search
 
 
 class ResearchRequest(BaseModel):
@@ -165,8 +161,8 @@ def ingest(req: IngestRequest):
 
 
 @app.post("/search")
-def search(req: SearchRequest):
-    results = search_vaults(
+def search_endpoint(req: SearchRequest):
+    results = search(
         req.query,
         req.vaults,
         k_per_vault=req.k_per_vault,

--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -2,7 +2,8 @@ import argparse
 import uvicorn
 
 from .api import app, run_research
-from .ingest import start_watcher, search_vaults
+from .ingest import start_watcher
+from . import search
 
 
 def main(argv=None):
@@ -105,7 +106,7 @@ def main(argv=None):
             reddit_client_secret=args.reddit_client_secret,
         )
     elif args.command == "search":
-        results = search_vaults(
+        results = search(
             args.query,
             args.vaults.split(","),
             k_per_vault=args.k_per_vault,

--- a/src/tino_storm/ingestion/arxiv.py
+++ b/src/tino_storm/ingestion/arxiv.py
@@ -28,8 +28,16 @@ class ArxivScraper:
     """Fetch paper metadata and PDF text from arXiv."""
 
     def _pdf_text(self, url: str) -> str:
+        global PdfReader
         if PdfReader is None:
-            return ""
+            try:
+                from pypdf import PdfReader as _Reader  # type: ignore
+            except Exception:  # pragma: no cover - optional dependency
+                try:
+                    from PyPDF2 import PdfReader as _Reader  # type: ignore
+                except Exception:
+                    return ""
+            PdfReader = _Reader
         try:
             log_request("GET", url)
             resp = requests.get(url, timeout=10)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -176,7 +176,7 @@ def test_search_endpoint(monkeypatch):
         called["args"] = (query, list(vaults), k_per_vault, rrf_k)
         return [{"url": "u", "snippets": ["s"]}]
 
-    monkeypatch.setattr("tino_storm.api.search_vaults", fake_search)
+    monkeypatch.setattr("tino_storm.api.search", fake_search)
     client = TestClient(app)
     resp = client.post("/search", json={"query": "q", "vaults": ["v1", "v2"]})
     assert resp.status_code == 200

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,8 +123,7 @@ def test_cli_search(monkeypatch, capsys):
         calls.append((query, list(vaults), k_per_vault, rrf_k))
         return [{"url": "example.com", "snippets": ["result"]}]
 
-    monkeypatch.setattr("tino_storm.ingest.search_vaults", fake_search)
-    monkeypatch.setattr("tino_storm.cli.search_vaults", fake_search)
+    monkeypatch.setattr("tino_storm.cli.search", fake_search)
 
     main(["search", "--query", "ai", "--vaults", "science,notes"])
 


### PR DESCRIPTION
## Summary
- switch CLI to use high-level `search()` helper
- switch API search endpoint to use same helper
- keep search parameters in CLI and API
- fix ArxivScraper PDF parsing when PdfReader becomes available late
- update unit tests for new search usage

## Testing
- `ruff check src/tino_storm/api.py src/tino_storm/cli.py tests/test_api_endpoints.py tests/test_cli.py`
- `black --check src/tino_storm/api.py src/tino_storm/cli.py tests/test_api_endpoints.py tests/test_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c9a991a4832683016813c7fd6c27