### PR TITLE
Add pluggable search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ import tino_storm
 results = await tino_storm.search("machine learning", ["science"])
 ```
 
+### Custom search providers
+
+`tino_storm.search()` can use a pluggable provider for fetching results.  Pass
+an instance to the `provider` argument or set the `STORM_SEARCH_PROVIDER`
+environment variable to the dotted path of a provider class.
+
+```python
+from tino_storm.providers import Provider
+
+class MyProvider(Provider):
+    def search_sync(self, query, vaults, **kwargs):
+        ...  # return list of results
+
+results = tino_storm.search("cats", ["science"], provider=MyProvider())
+```
+
 ### HTTP API
 
 When running `tino-storm serve` the following POST endpoints become available:

--- a/src/tino_storm/providers/__init__.py
+++ b/src/tino_storm/providers/__init__.py
@@ -1,0 +1,3 @@
+from .base import Provider, DefaultProvider, load_provider
+
+__all__ = ["Provider", "DefaultProvider", "load_provider"]

--- a/src/tino_storm/providers/base.py
+++ b/src/tino_storm/providers/base.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+from abc import ABC, abstractmethod
+from typing import Iterable, List, Dict, Any, Optional
+
+from ..ingest import search_vaults
+from ..core.rm import BingSearch
+
+
+class Provider(ABC):
+    """Base interface for search providers."""
+
+    async def search_async(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Asynchronously search and return results."""
+        return await asyncio.to_thread(
+            self.search_sync,
+            query,
+            vaults,
+            k_per_vault=k_per_vault,
+            rrf_k=rrf_k,
+            chroma_path=chroma_path,
+            vault=vault,
+        )
+
+    @abstractmethod
+    def search_sync(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Synchronously search and return results."""
+
+    def search(self, *args, **kwargs):
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return self.search_sync(*args, **kwargs)
+        return self.search_async(*args, **kwargs)
+
+
+class DefaultProvider(Provider):
+    """Default provider using local vaults and optional Bing search."""
+
+    def __init__(self, bing_k: int = 5, **bing_kwargs):
+        self.bing_k = bing_k
+        self.bing_kwargs = bing_kwargs
+        self._bing = None
+
+    def _bing_search(self, query: str) -> List[Dict[str, Any]]:
+        if self._bing is None:
+            api_key = os.environ.get("BING_SEARCH_API_KEY")
+            if not api_key:
+                return []
+            self._bing = BingSearch(
+                bing_search_api_key=api_key, k=self.bing_k, **self.bing_kwargs
+            )
+        return self._bing(query)
+
+    def search_sync(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        results = search_vaults(
+            query,
+            vaults,
+            k_per_vault=k_per_vault,
+            rrf_k=rrf_k,
+            chroma_path=chroma_path,
+            vault=vault,
+        )
+        if results:
+            return results
+        web = self._bing_search(query)
+        formatted = []
+        for item in web:
+            formatted.append(
+                {
+                    "url": item.get("url"),
+                    "snippets": item.get("snippets") or [item.get("description", "")],
+                    "meta": {"title": item.get("title")},
+                }
+            )
+        return formatted
+
+
+def load_provider(spec: str) -> Provider:
+    module_name, obj = spec.rsplit(".", 1)
+    mod = importlib.import_module(module_name)
+    cls = getattr(mod, obj)
+    return cls()

--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -1,7 +1,20 @@
 import asyncio
 from typing import Iterable, List, Dict, Any, Optional
 
-from .ingest import search_vaults
+import os
+
+from .providers import DefaultProvider, load_provider, Provider
+
+
+def _resolve_provider(provider: Provider | str | None) -> Provider:
+    if provider is None:
+        spec = os.environ.get("STORM_SEARCH_PROVIDER")
+        if spec:
+            return load_provider(spec)
+        return DefaultProvider()
+    if isinstance(provider, str):
+        return load_provider(provider)
+    return provider
 
 
 async def search_async(
@@ -12,11 +25,12 @@ async def search_async(
     rrf_k: int = 60,
     chroma_path: Optional[str] = None,
     vault: Optional[str] = None,
+    provider: Provider | str | None = None,
 ) -> List[Dict[str, Any]]:
-    """Asynchronously query ``vaults`` using :func:`search_vaults` in a thread."""
+    """Asynchronously query ``vaults`` using the configured provider."""
 
-    return await asyncio.to_thread(
-        search_vaults,
+    provider = _resolve_provider(provider)
+    return await provider.search_async(
         query,
         vaults,
         k_per_vault=k_per_vault,
@@ -34,13 +48,15 @@ def search(
     rrf_k: int = 60,
     chroma_path: Optional[str] = None,
     vault: Optional[str] = None,
+    provider: Provider | str | None = None,
 ):
     """Query ``vaults`` synchronously or return an awaitable when in an event loop."""
 
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        return search_vaults(
+        provider = _resolve_provider(provider)
+        return provider.search_sync(
             query,
             vaults,
             k_per_vault=k_per_vault,
@@ -56,4 +72,5 @@ def search(
         rrf_k=rrf_k,
         chroma_path=chroma_path,
         vault=vault,
+        provider=provider,
     )

--- a/tests/test_search_function.py
+++ b/tests/test_search_function.py
@@ -9,14 +9,33 @@ def test_search_sync(monkeypatch):
 
     called = {}
 
-    def fake_search_vaults(
-        query, vaults, *, k_per_vault=5, rrf_k=60, chroma_path=None, vault=None
-    ):
-        called["args"] = (query, list(vaults), k_per_vault, rrf_k, chroma_path, vault)
-        return ["ok"]
-
     search_mod = importlib.import_module("tino_storm.search")
-    monkeypatch.setattr(search_mod, "search_vaults", fake_search_vaults)
+
+    class FakeProvider(search_mod.Provider):
+        def search_sync(
+            self,
+            query,
+            vaults,
+            *,
+            k_per_vault=5,
+            rrf_k=60,
+            chroma_path=None,
+            vault=None,
+        ):
+            called["args"] = (
+                query,
+                list(vaults),
+                k_per_vault,
+                rrf_k,
+                chroma_path,
+                vault,
+            )
+            return ["ok"]
+
+    fake_provider = FakeProvider()
+    monkeypatch.setattr(
+        search_mod, "_resolve_provider", lambda provider=None: fake_provider
+    )
     # restore attribute pointing to function after importing module
     tino_storm.search = search_mod.search
     tino_storm.search_async = search_mod.search_async
@@ -30,21 +49,40 @@ def test_search_sync(monkeypatch):
 def test_search_async(monkeypatch):
     """search() should delegate to asyncio.to_thread inside an event loop."""
 
+    search_mod = importlib.import_module("tino_storm.search")
     called = {}
 
     async def fake_to_thread(func, *a, **k):
         called["thread"] = True
         return func(*a, **k)
 
-    def fake_search_vaults(
-        query, vaults, *, k_per_vault=5, rrf_k=60, chroma_path=None, vault=None
-    ):
-        called["args"] = (query, list(vaults), k_per_vault, rrf_k, chroma_path, vault)
-        return ["async"]
+    class FakeProvider(search_mod.Provider):
+        def search_sync(
+            self,
+            query,
+            vaults,
+            *,
+            k_per_vault=5,
+            rrf_k=60,
+            chroma_path=None,
+            vault=None,
+        ):
+            called["sync"] = True
+            called["args"] = (
+                query,
+                list(vaults),
+                k_per_vault,
+                rrf_k,
+                chroma_path,
+                vault,
+            )
+            return ["async"]
 
-    search_mod = importlib.import_module("tino_storm.search")
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
-    monkeypatch.setattr(search_mod, "search_vaults", fake_search_vaults)
+    fake_provider = FakeProvider()
+    monkeypatch.setattr(
+        search_mod, "_resolve_provider", lambda provider=None: fake_provider
+    )
     tino_storm.search = search_mod.search
     tino_storm.search_async = search_mod.search_async
 


### PR DESCRIPTION
## Summary
- add Provider base and DefaultProvider combining vault and Bing search
- extend `search()` to use providers from parameter or `STORM_SEARCH_PROVIDER`
- document custom providers in README
- test updates for provider logic

## Testing
- `pre-commit run --files README.md src/tino_storm/search.py src/tino_storm/providers/base.py src/tino_storm/providers/__init__.py tests/test_search_function.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c9a8f3888326a9110b664064a54b