### PR TITLE
Handle provider network errors

### DIFF
--- a/src/tino_storm/core/rm.py
+++ b/src/tino_storm/core/rm.py
@@ -8,6 +8,7 @@ import requests
 
 from ..security import log_request
 from dsp import backoff_hdlr, giveup_hdlr
+from ..events import ResearchAdded, event_emitter
 
 from .utils import WebPageHelper
 
@@ -74,6 +75,18 @@ class YouRM(dspy.Retrieve):
                     collected_results.extend(authoritative_results[: self.k])
             except Exception as e:
                 logging.error(f"Error occurs when searching query {query}: {e}")
+                event_emitter.emit(
+                    ResearchAdded(topic=query, information_table={"error": str(e)})
+                )
+                event_emitter.emit(
+                    ResearchAdded(topic=query, information_table={"error": str(e)})
+                )
+                event_emitter.emit(
+                    ResearchAdded(topic=query, information_table={"error": str(e)})
+                )
+                event_emitter.emit(
+                    ResearchAdded(topic=query, information_table={"error": str(e)})
+                )
 
         return collected_results
 
@@ -169,9 +182,16 @@ class BingSearch(dspy.Retrieve):
             except Exception as e:
                 logging.error(f"Error occurs when searching query {query}: {e}")
 
-        valid_url_to_snippets = self.webpage_helper.urls_to_snippets(
-            list(url_to_results.keys())
-        )
+        try:
+            valid_url_to_snippets = self.webpage_helper.urls_to_snippets(
+                list(url_to_results.keys())
+            )
+        except Exception as e:
+            logging.error(f"Error occurs when fetching webpages for {queries}: {e}")
+            event_emitter.emit(
+                ResearchAdded(topic=str(queries), information_table={"error": str(e)})
+            )
+            valid_url_to_snippets = {}
         collected_results = []
         for url in valid_url_to_snippets:
             r = url_to_results[url]
@@ -406,6 +426,9 @@ class StanfordOvalArxivRM(dspy.Retrieve):
                 collected_results.extend(results)
             except Exception as e:
                 logging.error(f"Error occurs when searching query {query}: {e}")
+                event_emitter.emit(
+                    ResearchAdded(topic=query, information_table={"error": str(e)})
+                )
         return collected_results
 
 

--- a/tests/test_provider_errors.py
+++ b/tests/test_provider_errors.py
@@ -1,0 +1,26 @@
+from tino_storm.providers import DefaultProvider
+from tino_storm.events import event_emitter, ResearchAdded
+
+
+def test_bing_error_emits_event(monkeypatch):
+    monkeypatch.setattr(event_emitter, "_subscribers", {})
+    events = []
+    event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
+
+    monkeypatch.setattr("tino_storm.providers.base.search_vaults", lambda *a, **k: [])
+
+    class DummyBing:
+        def __init__(self, *a, **k):
+            pass
+
+        def __call__(self, query):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("tino_storm.providers.base.BingSearch", DummyBing)
+
+    provider = DefaultProvider()
+    result = provider.search_sync("topic", [])
+    assert result == []
+    assert len(events) == 1
+    assert events[0].topic == "topic"
+    assert events[0].information_table["error"] == "boom"


### PR DESCRIPTION
## Summary
- add logging and ResearchAdded events for Bing errors
- emit ResearchAdded when retrieval modules fail
- test provider error handling

## Testing
- `pre-commit run --files src/tino_storm/providers/base.py src/tino_storm/core/rm.py tests/test_provider_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_6887dc03426483269eef561229b93baa