### PR TITLE
Add research plugin docs and async example

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,27 @@ skill.optimize()
 result = skill("The Eiffel Tower")
 ```
 
+## Using Tino Storm as a research plugin
+
+`tino_storm.search()` can be called from other applications to retrieve
+documents from STORM vaults. When executed inside an event loop the function
+delegates to its asynchronous counterpart, allowing seamless integration as a
+plugin.
+
+```python
+import asyncio
+import tino_storm
+
+async def main():
+    results = await tino_storm.search("large language models", ["science"])
+    print(results)
+
+asyncio.run(main())
+```
+
+See [docs/research_plugin.md](docs/research_plugin.md) and the example under
+[`examples/async_search.py`](examples/async_search.py) for more details.
+
 ## Ingesting your own data
 
 STORM can be grounded on a custom corpus by creating a Qdrant vector store and

--- a/docs/research_plugin.md
+++ b/docs/research_plugin.md
@@ -1,0 +1,16 @@
+# Using Tino Storm as a research plugin
+
+`tino_storm.search()` and `tino_storm.search_async()` can be embedded in language-model agents to query one or more STORM vaults. The synchronous helper automatically delegates to `search_async()` when an event loop is active.
+
+```python
+import asyncio
+import tino_storm
+
+async def main():
+    results = await tino_storm.search("large language models", ["science"])
+    print(results)
+
+asyncio.run(main())
+```
+
+The search API returns a list of result dictionaries containing the URL, title and text snippets from the retrieved documents.

--- a/examples/async_search.py
+++ b/examples/async_search.py
@@ -1,0 +1,15 @@
+"""Example demonstrating asynchronous search usage."""
+
+import asyncio
+import tino_storm
+
+
+async def main() -> None:
+    results = await tino_storm.search("large language models", ["science"])
+    for item in results:
+        snippet = item.get("snippets", [""])[0]
+        print(f"{item['url']}: {snippet[:80]}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- document using Tino Storm as a research plugin
- add async example script

## Testing
- `ruff check examples/async_search.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887eaf17a488326bc0311af29655802