### PR TITLE
Check provider subclass when loading

### DIFF
--- a/src/tino_storm/providers/base.py
+++ b/src/tino_storm/providers/base.py
@@ -119,4 +119,6 @@ def load_provider(spec: str) -> Provider:
     module_name, obj = spec.rsplit(".", 1)
     mod = importlib.import_module(module_name)
     cls = getattr(mod, obj)
+    if not issubclass(cls, Provider):
+        raise TypeError(f"{cls.__module__}.{cls.__name__} is not a Provider")
     return cls()

--- a/tests/test_load_provider.py
+++ b/tests/test_load_provider.py
@@ -1,0 +1,39 @@
+import sys
+import types
+import pytest
+
+from tino_storm.providers import Provider, load_provider
+
+
+def test_load_provider_requires_subclass():
+    mod = types.ModuleType("dummy_provider")
+
+    class DummyProvider(Provider):
+        def search_sync(
+            self,
+            query,
+            vaults,
+            *,
+            k_per_vault=5,
+            rrf_k=60,
+            chroma_path=None,
+            vault=None,
+        ):
+            return []
+
+    class NotAProvider:
+        pass
+
+    DummyProvider.__module__ = "dummy_provider"
+    NotAProvider.__module__ = "dummy_provider"
+    mod.DummyProvider = DummyProvider
+    mod.NotAProvider = NotAProvider
+    sys.modules["dummy_provider"] = mod
+
+    provider = load_provider("dummy_provider.DummyProvider")
+    assert isinstance(provider, DummyProvider)
+
+    with pytest.raises(
+        TypeError, match="dummy_provider.NotAProvider is not a Provider"
+    ):
+        load_provider("dummy_provider.NotAProvider")


### PR DESCRIPTION
## Summary
- validate that dynamically loaded provider classes subclass `Provider`
- add tests for the new `load_provider` behavior

## Testing
- `pre-commit run --files src/tino_storm/providers/base.py tests/test_load_provider.py`

------
https://chatgpt.com/codex/tasks/task_e_68897d76bf9c8326bb00d8181d111e14