### PR TITLE
Add provider loading tests and fix subclass check

### DIFF
--- a/src/tino_storm/providers/base.py
+++ b/src/tino_storm/providers/base.py
@@ -119,4 +119,6 @@ def load_provider(spec: str) -> Provider:
     module_name, obj = spec.rsplit(".", 1)
     mod = importlib.import_module(module_name)
     cls = getattr(mod, obj)
+    if not isinstance(cls, type) or not issubclass(cls, Provider):
+        raise TypeError(f"{spec} is not a Provider subclass")
     return cls()

--- a/tests/test_provider_loading.py
+++ b/tests/test_provider_loading.py
@@ -1,0 +1,55 @@
+import sys
+import types
+
+import pytest
+
+import tino_storm
+from tino_storm.providers import Provider, load_provider
+
+
+def test_load_provider_raises(monkeypatch):
+    mod = types.ModuleType("dummy_mod")
+
+    class NotProvider:
+        pass
+
+    mod.NotProvider = NotProvider
+    monkeypatch.setitem(sys.modules, "dummy_mod", mod)
+
+    with pytest.raises(TypeError):
+        load_provider("dummy_mod.NotProvider")
+
+
+def test_search_uses_env_provider(monkeypatch):
+    calls = {}
+
+    class DummyProvider(Provider):
+        def search_sync(
+            self,
+            query,
+            vaults,
+            *,
+            k_per_vault=5,
+            rrf_k=60,
+            chroma_path=None,
+            vault=None,
+        ):
+            calls["args"] = (
+                query,
+                list(vaults),
+                k_per_vault,
+                rrf_k,
+                chroma_path,
+                vault,
+            )
+            return ["ok"]
+
+    mod = types.ModuleType("dummy_provider_mod")
+    mod.DummyProvider = DummyProvider
+    monkeypatch.setitem(sys.modules, "dummy_provider_mod", mod)
+    monkeypatch.setenv("STORM_SEARCH_PROVIDER", "dummy_provider_mod.DummyProvider")
+
+    result = tino_storm.search("q", ["v"])
+
+    assert result == ["ok"]
+    assert calls["args"] == ("q", ["v"], 5, 60, None, None)


### PR DESCRIPTION
## Summary
- ensure provider loader validates Provider subclass
- add tests for provider loading and env-based provider

## Testing
- `pre-commit run --files src/tino_storm/providers/base.py tests/test_provider_loading.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897d76ba6083268cfc16b36b00889d