### PR TITLE
Fix duplicate event emission and add regression test

### DIFF
--- a/src/tino_storm/core/rm.py
+++ b/src/tino_storm/core/rm.py
@@ -78,15 +78,6 @@ class YouRM(dspy.Retrieve):
                 event_emitter.emit(
                     ResearchAdded(topic=query, information_table={"error": str(e)})
                 )
-                event_emitter.emit(
-                    ResearchAdded(topic=query, information_table={"error": str(e)})
-                )
-                event_emitter.emit(
-                    ResearchAdded(topic=query, information_table={"error": str(e)})
-                )
-                event_emitter.emit(
-                    ResearchAdded(topic=query, information_table={"error": str(e)})
-                )
 
         return collected_results
 

--- a/tests/test_provider_errors.py
+++ b/tests/test_provider_errors.py
@@ -24,3 +24,26 @@ def test_bing_error_emits_event(monkeypatch):
     assert len(events) == 1
     assert events[0].topic == "topic"
     assert events[0].information_table["error"] == "boom"
+
+
+def test_yourm_error_emits_event_once(monkeypatch):
+    monkeypatch.setattr(event_emitter, "_subscribers", {})
+    events = []
+    event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
+
+    monkeypatch.setattr("tino_storm.security.audit.log_request", lambda *a, **k: None)
+
+    def raise_err(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("tino_storm.core.rm.requests.get", raise_err)
+
+    from tino_storm.core.rm import YouRM
+
+    rm = YouRM(ydc_api_key="x")
+    result = rm.forward("topic")
+
+    assert result == []
+    assert len(events) == 1
+    assert events[0].topic == "topic"
+    assert events[0].information_table["error"] == "boom"


### PR DESCRIPTION
## Summary
- avoid emitting multiple ResearchAdded events from `YouRM.forward`
- ensure YouRM emits a single event on errors

## Testing
- `pre-commit run --files src/tino_storm/core/rm.py tests/test_provider_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_688ac5e72b7883268df8d351a85e974b