### PR TITLE
Add watchdog dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,11 @@ This section contains technical instructions & hints for contributors.
 ### Setting up
 1. Fork this repository and clone your forked repository.
 2. Install the required packages:
-    ```
-    conda create -n storm python=3.11
-    conda activate storm
-    pip install -r requirements.txt
-    ```
+```
+conda create -n storm python=3.11
+conda activate storm
+pip install -r requirements.txt  # installs watchdog for the ingest watcher
+```
 3. If you want to contribute to `frontend/demo_light`, follow its [Setup guide](https://github.com/stanford-oval/storm/tree/main/frontend/demo_light#setup) to install additional packages.
 
 ### PR suggestions

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ $ tino-storm ingest --root ./vault
 ### The `ingest` command
 
 `ingest` runs a small watcher that monitors a "vault" directory for new files.
+The watcher relies on the [`watchdog`](https://pypi.org/project/watchdog/) package,
+which is installed automatically with `tino-storm`.
 Each first level subdirectory acts as the vault name. Dropped text files or
 files ending in `.url`/`.urls` are parsed and the contents stored in a local
 Chroma collection under `~/.tino_storm/chroma` (override with

--- a/docs/ingest.md
+++ b/docs/ingest.md
@@ -1,6 +1,9 @@
 # Ingestion folder layout
 
-`tino-storm ingest` monitors a directory for dropped files. The specified `--root` acts as the vault root where each first level subdirectory becomes a vault name.
+`tino-storm ingest` monitors a directory for dropped files. The watcher is powered by
+the [`watchdog`](https://pypi.org/project/watchdog/) package, which is installed
+automatically. The specified `--root` acts as the vault root where each first
+level subdirectory becomes a vault name.
 
 Example structure:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "cryptography>=41.0.0",
     "fastapi>=0.110.0",
     "uvicorn>=0.29.0",
+    "watchdog",
     "knowledge-storm",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ PyYAML>=6.0
 cryptography>=41.0.0
 fastapi>=0.110.0
 uvicorn>=0.29.0
+watchdog
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import importlib.util
 
 if "chromadb" not in sys.modules:
     chromadb = types.ModuleType("chromadb")
@@ -32,7 +33,7 @@ if "chromadb" not in sys.modules:
 else:
     DummyClient = sys.modules["chromadb"].PersistentClient
 
-if "watchdog.events" not in sys.modules:
+if importlib.util.find_spec("watchdog.events") is None:
     watchdog = types.ModuleType("watchdog")
     observers_mod = types.ModuleType("watchdog.observers")
 
@@ -131,3 +132,10 @@ def test_ingest_txt_documents(monkeypatch, tmp_path):
     collection = handler.client.get_or_create_collection("topic")
     assert collection.docs == ["d1", "d2"]
     assert len(events) == 2
+
+
+def test_handler_uses_watchdog(tmp_path):
+    from watchdog.events import FileSystemEventHandler
+
+    handler = VaultIngestHandler(root=str(tmp_path))
+    assert isinstance(handler, FileSystemEventHandler)


### PR DESCRIPTION
## Summary
- add watchdog to requirements and pyproject
- mention watchdog requirement in README and docs
- clarify setup instructions
- only stub watchdog in tests if missing and ensure tests run with real package
- verify VaultIngestHandler inherits from watchdog handler

## Testing
- `pre-commit run --files README.md docs/ingest.md CONTRIBUTING.md pyproject.toml requirements.txt tests/test_watcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ac5e7c88c832690a7b5ce32efb479