### PR TITLE
Add async search provider and awaiting test

### DIFF
--- a/src/tino_storm/providers/__init__.py
+++ b/src/tino_storm/providers/__init__.py
@@ -1,3 +1,4 @@
 from .base import Provider, DefaultProvider, load_provider
+from .dummy_async import DummyAsyncProvider
 
-__all__ = ["Provider", "DefaultProvider", "load_provider"]
+__all__ = ["Provider", "DefaultProvider", "load_provider", "DummyAsyncProvider"]

--- a/src/tino_storm/providers/dummy_async.py
+++ b/src/tino_storm/providers/dummy_async.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Dict, Any, Optional
+
+from .base import Provider
+
+
+class DummyAsyncProvider(Provider):
+    """Provider with an asynchronous search method for testing."""
+
+    async def search_async(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        return [{"query": query, "vaults": list(vaults)}]
+
+    def search_sync(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        raise NotImplementedError("DummyAsyncProvider only implements search_async")

--- a/tests/test_search_function.py
+++ b/tests/test_search_function.py
@@ -94,3 +94,51 @@ def test_search_async(monkeypatch):
     assert result == ["async"]
     assert called["thread"]
     assert called["args"] == ("q", ["v"], 5, 60, None, None)
+
+
+def test_search_awaits_provider_coroutine(monkeypatch):
+    """search() should await Provider.search_async when defined."""
+
+    search_mod = importlib.import_module("tino_storm.search")
+    called = {}
+
+    class AsyncProvider(search_mod.Provider):
+        async def search_async(
+            self,
+            query,
+            vaults,
+            *,
+            k_per_vault=5,
+            rrf_k=60,
+            chroma_path=None,
+            vault=None,
+        ):
+            called["args"] = (
+                query,
+                list(vaults),
+                k_per_vault,
+                rrf_k,
+                chroma_path,
+                vault,
+            )
+            return ["awaited"]
+
+        def search_sync(self, *a, **k):
+            called["sync"] = True
+            return []
+
+    provider_instance = AsyncProvider()
+    monkeypatch.setattr(
+        search_mod, "_resolve_provider", lambda provider=None: provider_instance
+    )
+    tino_storm.search = search_mod.search
+    tino_storm.search_async = search_mod.search_async
+
+    async def _run():
+        return await tino_storm.search("q", ["v"])
+
+    result = asyncio.run(_run())
+
+    assert result == ["awaited"]
+    assert called["args"] == ("q", ["v"], 5, 60, None, None)
+    assert "sync" not in called


### PR DESCRIPTION
## Summary
- implement a dummy provider with an async `search_async`
- export `DummyAsyncProvider`
- ensure `search()` awaits provider coroutines when inside an event loop

## Testing
- `pre-commit run --files src/tino_storm/providers/dummy_async.py src/tino_storm/providers/__init__.py tests/test_search_function.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688acb4c77e88326aa01b3d41665f346