### PR TITLE
Resolve ruff issues in example and demo scripts

### DIFF
--- a/examples/costorm_examples/run_costorm_gpt.py
+++ b/examples/costorm_examples/run_costorm_gpt.py
@@ -64,7 +64,6 @@ def main(args):
     )
     # If you are using Azure service, make sure the model name matches your own deployed model name.
     # The default name here is only used for demonstration and may not match your case.
-    gpt_4o_mini_model_name = "gpt-4o-mini"
     gpt_4o_model_name = "gpt-4o"
     if os.getenv("OPENAI_API_TYPE") == "azure":
         openai_kwargs["api_base"] = os.getenv("AZURE_API_BASE")

--- a/examples/storm_examples/run_storm_wiki_groq.py
+++ b/examples/storm_examples/run_storm_wiki_groq.py
@@ -19,17 +19,15 @@ args.output_dir/
 
 import os
 import re
+import logging
 from argparse import ArgumentParser
 
+from lm import GroqModel
 from tino_storm import (
     STORMWikiRunnerArguments,
     STORMWikiRunner,
     STORMWikiLMConfigs,
 )
-
-# Now import lm directly
-import lm
-from lm import GroqModel
 from tino_storm.rm import (
     YouRM,
     BingSearch,
@@ -40,6 +38,8 @@ from tino_storm.rm import (
     SearXNG,
 )
 from tino_storm.utils import load_api_key
+
+logger = logging.getLogger(__name__)
 
 
 def sanitize_topic(topic):

--- a/examples/storm_examples/run_storm_wiki_ollama.py
+++ b/examples/storm_examples/run_storm_wiki_ollama.py
@@ -17,7 +17,6 @@ args.output_dir/
 """
 
 import os
-import sys
 from argparse import ArgumentParser
 
 from dspy import Example

--- a/frontend/demo_light/demo_util.py
+++ b/frontend/demo_light/demo_util.py
@@ -21,7 +21,6 @@ from tino_storm import (
 from tino_storm.lm import OpenAIModel
 from tino_storm.rm import YouRM
 from tino_storm.storm_wiki.modules.callback import BaseCallbackHandler
-from tino_storm.utils import truncate_filename
 from stoc import stoc
 
 
@@ -670,8 +669,8 @@ class StreamlitCallbackHandler(BaseCallbackHandler):
 
     def on_direct_outline_generation_end(self, outline: str, **kwargs):
         self.status_container.success(
-            f"Finish leveraging the internal knowledge of the large language model."
+            "Finish leveraging the internal knowledge of the large language model."
         )
 
     def on_outline_refinement_end(self, outline: str, **kwargs):
-        self.status_container.success(f"Finish leveraging the collected information.")
+        self.status_container.success("Finish leveraging the collected information.")

--- a/frontend/demo_light/pages_util/CreateNewArticle.py
+++ b/frontend/demo_light/pages_util/CreateNewArticle.py
@@ -5,7 +5,6 @@ import demo_util
 import streamlit as st
 from demo_util import (
     DemoFileIOHelper,
-    DemoTextProcessingHelper,
     DemoUIHelper,
     truncate_filename,
 )

--- a/frontend/demo_light/pages_util/MyArticles.py
+++ b/frontend/demo_light/pages_util/MyArticles.py
@@ -30,7 +30,6 @@ def my_articles_page():
     # if no feature demo selected, display all featured articles as info cards
     def article_card_setup(column_to_add, card_title, article_name):
         with column_to_add:
-            cleaned_article_title = article_name.replace("_", " ")
             hasClicked = card(
                 title=" / ".join(card_title),
                 text=article_name.replace("_", " "),

--- a/frontend/demo_light/storm.py
+++ b/frontend/demo_light/storm.py
@@ -1,12 +1,13 @@
 import os
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-wiki_root_dir = os.path.dirname(os.path.dirname(script_dir))
+import streamlit as st
+from streamlit_option_menu import option_menu
 
 import demo_util
-from pages_util import MyArticles, CreateNewArticle
-from streamlit_float import *
-from streamlit_option_menu import option_menu
+from pages_util import CreateNewArticle, MyArticles
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+wiki_root_dir = os.path.dirname(os.path.dirname(script_dir))
 
 
 def main():
@@ -19,7 +20,7 @@ def main():
     # set api keys from secrets
     if st.session_state["first_run"]:
         for key, value in st.secrets.items():
-            if type(value) == str:
+            if isinstance(value, str):
                 os.environ[key] = value
 
     # initialize session_state


### PR DESCRIPTION
## Summary
- address unused variable in Co-STORM example
- clean up imports and logging in Groq example script
- remove unused imports from Ollama example
- fix ruff warnings in `demo_light` utilities and pages
- switch `storm.py` to explicit Streamlit import

## Testing
- `ruff check examples/ frontend/demo_light`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b86b0af5c8326980cb768116913a5