### PR TITLE
Add scraper optional dependencies and document installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ pip install -e .
 which tino-storm
 ```
 
+## Optional scraper dependencies
+
+The ingestion helpers rely on optional libraries for scraping data from
+social platforms and PDF files. Install them with:
+
+```bash
+pip install tino-storm[scrapers]
+```
+
 ## Command line usage
 
 `tino-storm` provides a simple CLI.  The `run` sub-command executes a single

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,13 @@ dependencies = [
 [project.scripts]
 tino-storm = "tino_storm.cli:main"
 
+[project.optional-dependencies]
+scrapers = [
+    "snscrape",
+    "praw",
+    "pypdf",
+]
+
 [build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add optional `scrapers` extra in `pyproject.toml`
- document extra packages in README with installation example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b86b03e788326b90ca86971829010