### PR TITLE
Add helper for enumerating research vaults

### DIFF
--- a/src/tino_storm/ingest/search.py
+++ b/src/tino_storm/ingest/search.py
@@ -19,6 +19,25 @@ from ..retrieval.scoring import score_results
 from ..retrieval.bayes import add_posteriors
 
 
+def list_vaults(root: Optional[str] = None) -> list[str]:
+    """Return available vault directories under ``root``.
+
+    If ``root`` is not provided, the ``STORM_VAULT_ROOT`` environment variable is
+    consulted. If that is unset, the default ``~/.tino_storm/research`` directory
+    is used. Only sub-directories are returned and the result is sorted
+    alphabetically.
+    """
+
+    root_path = Path(
+        root or os.environ.get("STORM_VAULT_ROOT") or Path.home() / ".tino_storm" / "research"
+    ).expanduser()
+
+    if not root_path.exists():
+        return []
+
+    return sorted(p.name for p in root_path.iterdir() if p.is_dir())
+
+
 def search_vaults(
     query: str,
     vaults: Iterable[str],

--- a/tests/test_list_vaults.py
+++ b/tests/test_list_vaults.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from tino_storm.ingest.search import list_vaults  # noqa: E402
+
+
+def _make_vaults(root: str, names: list[str]) -> None:
+    for name in names:
+        os.makedirs(os.path.join(root, name))
+
+
+def test_list_vaults_default_root(tmp_path, monkeypatch):
+    vault_root = tmp_path / "research"
+    _make_vaults(vault_root, ["v1", "v2"])
+    (vault_root / "file.txt").write_text("not a vault")
+
+    monkeypatch.setenv("STORM_VAULT_ROOT", str(vault_root))
+
+    assert set(list_vaults()) == {"v1", "v2"}
+
+
+def test_list_vaults_custom_root(tmp_path, monkeypatch):
+    env_root = tmp_path / "env"
+    _make_vaults(env_root, ["ignored"])
+    monkeypatch.setenv("STORM_VAULT_ROOT", str(env_root))
+
+    custom_root = tmp_path / "custom"
+    _make_vaults(custom_root, ["a", "b"])
+
+    assert set(list_vaults(str(custom_root))) == {"a", "b"}
+


### PR DESCRIPTION
## Summary
- add `list_vaults` helper to enumerate available vault directories
- test vault listing with default and custom roots

## Testing
- `ruff check src/tino_storm/ingest/search.py tests/test_list_vaults.py`
- `pytest tests/test_list_vaults.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897fcb0ca9c8326825e51ed8d3471f2