### PR TITLE
Default to available vaults in search

### DIFF
--- a/tests/test_search_function.py
+++ b/tests/test_search_function.py
@@ -142,3 +142,49 @@ def test_search_awaits_provider_coroutine(monkeypatch):
     assert result == ["awaited"]
     assert called["args"] == ("q", ["v"], 5, 60, None, None)
     assert "sync" not in called
+
+
+def test_search_without_vaults_uses_default(monkeypatch):
+    """search() without vaults should fall back to list_vaults."""
+
+    search_mod = importlib.import_module("tino_storm.search")
+    called = {}
+
+    def fake_list_vaults():
+        called["list"] = True
+        return ["a", "b"]
+
+    class FakeProvider(search_mod.Provider):
+        def search_sync(
+            self,
+            query,
+            vaults,
+            *,
+            k_per_vault=5,
+            rrf_k=60,
+            chroma_path=None,
+            vault=None,
+        ):
+            called["args"] = (
+                query,
+                list(vaults),
+                k_per_vault,
+                rrf_k,
+                chroma_path,
+                vault,
+            )
+            return ["ok"]
+
+    monkeypatch.setattr(search_mod, "list_vaults", fake_list_vaults)
+    fake_provider = FakeProvider()
+    monkeypatch.setattr(
+        search_mod, "_resolve_provider", lambda provider=None: fake_provider
+    )
+    tino_storm.search = search_mod.search
+    tino_storm.search_async = search_mod.search_async
+
+    result = tino_storm.search("q")
+
+    assert result == ["ok"]
+    assert called["list"]
+    assert called["args"] == ("q", ["a", "b"], 5, 60, None, None)


### PR DESCRIPTION
## Summary
- Allow `search` and `search_async` to run without explicit vaults by falling back to `list_vaults`
- Add test covering `search("q")` without specifying vaults

## Testing
- `pre-commit run --files src/tino_storm/search.py tests/test_search_function.py`


------
https://chatgpt.com/codex/tasks/task_e_6897fcb18de4832694a62e8383172f56