### PR TITLE
Handle provider search errors

### DIFF
--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -3,8 +3,10 @@ from typing import Iterable, List, Dict, Any, Optional
 from pathlib import Path
 
 import os
+import logging
 
 from .providers import DefaultProvider, load_provider, Provider
+from .events import ResearchAdded, event_emitter
 
 
 def _resolve_provider(provider: Provider | str | None) -> Provider:
@@ -45,14 +47,21 @@ async def search_async(
         vaults = list_vaults()
 
     provider = _resolve_provider(provider)
-    return await provider.search_async(
-        query,
-        vaults,
-        k_per_vault=k_per_vault,
-        rrf_k=rrf_k,
-        chroma_path=chroma_path,
-        vault=vault,
-    )
+    try:
+        return await provider.search_async(
+            query,
+            vaults,
+            k_per_vault=k_per_vault,
+            rrf_k=rrf_k,
+            chroma_path=chroma_path,
+            vault=vault,
+        )
+    except Exception as e:
+        logging.error(f"Search failed for query {query}: {e}")
+        event_emitter.emit(
+            ResearchAdded(topic=query, information_table={"error": str(e)})
+        )
+        return []
 
 
 def search(
@@ -74,14 +83,21 @@ def search(
         asyncio.get_running_loop()
     except RuntimeError:
         provider = _resolve_provider(provider)
-        return provider.search_sync(
-            query,
-            vaults,
-            k_per_vault=k_per_vault,
-            rrf_k=rrf_k,
-            chroma_path=chroma_path,
-            vault=vault,
-        )
+        try:
+            return provider.search_sync(
+                query,
+                vaults,
+                k_per_vault=k_per_vault,
+                rrf_k=rrf_k,
+                chroma_path=chroma_path,
+                vault=vault,
+            )
+        except Exception as e:
+            logging.error(f"Search failed for query {query}: {e}")
+            event_emitter.emit(
+                ResearchAdded(topic=query, information_table={"error": str(e)})
+            )
+            return []
 
     return search_async(
         query,

--- a/tests/test_search_errors.py
+++ b/tests/test_search_errors.py
@@ -1,0 +1,43 @@
+from tino_storm.search import search, search_async, Provider
+from tino_storm.events import event_emitter, ResearchAdded
+import asyncio
+
+
+def test_search_sync_error_emits_event(monkeypatch):
+    monkeypatch.setattr(event_emitter, "_subscribers", {})
+    events = []
+    event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
+
+    class FailingProvider(Provider):
+        def search_sync(self, *a, **k):
+            raise RuntimeError("boom")
+
+    result = search("topic", provider=FailingProvider())
+
+    assert result == []
+    assert len(events) == 1
+    assert events[0].topic == "topic"
+    assert events[0].information_table["error"] == "boom"
+
+
+def test_search_async_error_emits_event(monkeypatch):
+    monkeypatch.setattr(event_emitter, "_subscribers", {})
+    events = []
+    event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
+
+    class FailingProvider(Provider):
+        async def search_async(self, *a, **k):
+            raise RuntimeError("boom")
+
+        def search_sync(self, *a, **k):
+            raise AssertionError("should not be called")
+
+    async def run():
+        return await search_async("topic", provider=FailingProvider())
+
+    result = asyncio.run(run())
+
+    assert result == []
+    assert len(events) == 1
+    assert events[0].topic == "topic"
+    assert events[0].information_table["error"] == "boom"


### PR DESCRIPTION
## Summary
- log and emit `ResearchAdded` when provider search fails
- return empty results on both sync and async search errors
- test error handling in search module

## Testing
- `SKIP=pytest pre-commit run --files src/tino_storm/search.py tests/test_search_errors.py`
- `pytest tests/test_search_function.py tests/test_provider_errors.py tests/test_search_errors.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689802164858832688a08052cfe756e6