### PR TITLE
Allow calling tino_storm module

### DIFF
--- a/src/tino_storm/__init__.py
+++ b/src/tino_storm/__init__.py
@@ -4,6 +4,12 @@ Primary classes are exposed here via lazy imports to avoid heavy
 dependencies unless needed."""
 
 from importlib import import_module
+import sys
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .search import search
 
 __all__ = [
     "__version__",
@@ -47,3 +53,15 @@ def __getattr__(name: str):
         globals()[name] = value
         return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __call__(query: str, **kwargs):
+    return search(query, **kwargs)
+
+
+class _CallableModule(ModuleType):
+    def __call__(self, query: str, **kwargs):
+        return search(query, **kwargs)
+
+
+sys.modules[__name__].__class__ = _CallableModule

--- a/tests/test_module_callable.py
+++ b/tests/test_module_callable.py
@@ -1,0 +1,17 @@
+import tino_storm
+
+
+def test_module_callable(monkeypatch):
+    calls = {}
+
+    def fake_search(query, **kwargs):
+        calls["query"] = query
+        calls["kwargs"] = kwargs
+        return "result"
+
+    monkeypatch.setitem(tino_storm.__dict__, "search", fake_search)
+
+    result = tino_storm("my query", foo="bar")
+
+    assert result == "result"
+    assert calls == {"query": "my query", "kwargs": {"foo": "bar"}}


### PR DESCRIPTION
## Summary
- Forward calls to `tino_storm` directly to the `search` function
- Add regression test ensuring module calls delegate to `search`

## Testing
- `pre-commit run --files src/tino_storm/__init__.py tests/test_module_callable.py`
- `pytest tests/test_module_callable.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8397bd008326a03e61319a43c1fe