### PR TITLE
Add provider registry integration test

### DIFF
--- a/src/tino_storm/providers/__init__.py
+++ b/src/tino_storm/providers/__init__.py
@@ -1,5 +1,12 @@
 from .base import Provider, DefaultProvider, load_provider
 from .parallel import ParallelProvider
+from .registry import ProviderRegistry, provider_registry
 
-__all__ = ["Provider", "DefaultProvider", "ParallelProvider", "load_provider"]
-
+__all__ = [
+    "Provider",
+    "DefaultProvider",
+    "ParallelProvider",
+    "load_provider",
+    "ProviderRegistry",
+    "provider_registry",
+]

--- a/src/tino_storm/providers/registry.py
+++ b/src/tino_storm/providers/registry.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from .base import Provider
+
+
+class ProviderRegistry:
+    """Registry mapping names to provider classes."""
+
+    def __init__(self) -> None:
+        self._providers: Dict[str, Type[Provider]] = {}
+
+    def register(self, name: str, provider_cls: Type[Provider]) -> None:
+        """Register a provider class under ``name``."""
+        if not issubclass(provider_cls, Provider):
+            raise TypeError("provider_cls must subclass Provider")
+        self._providers[name] = provider_cls
+
+    def get(self, name: str) -> Provider:
+        """Return an instance of the provider registered under ``name``."""
+        cls = self._providers[name]
+        return cls()
+
+    def clear(self) -> None:
+        """Remove all registered providers."""
+        self._providers.clear()
+
+
+provider_registry = ProviderRegistry()
+
+__all__ = ["ProviderRegistry", "provider_registry"]

--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -5,9 +5,13 @@ from pathlib import Path
 import os
 import logging
 
-from .providers import DefaultProvider, load_provider, Provider
+from .providers import (
+    DefaultProvider,
+    load_provider,
+    Provider,
+    provider_registry,
+)
 from .events import ResearchAdded, event_emitter
-
 
 
 def _resolve_provider(provider: Provider | str | None) -> Provider:
@@ -17,7 +21,10 @@ def _resolve_provider(provider: Provider | str | None) -> Provider:
             return load_provider(spec)
         return DefaultProvider()
     if isinstance(provider, str):
-        return load_provider(provider)
+        try:
+            return provider_registry.get(provider)
+        except KeyError:
+            return load_provider(provider)
     return provider
 
 

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,0 +1,33 @@
+import tino_storm
+from tino_storm.providers import Provider, provider_registry
+
+
+class SampleProvider(Provider):
+    def search_sync(
+        self,
+        query,
+        vaults,
+        *,
+        k_per_vault=5,
+        rrf_k=60,
+        chroma_path=None,
+        vault=None,
+    ):
+        return [{"url": "custom", "snippets": ["ok"], "meta": {}}]
+
+
+def setup_function(_):
+    provider_registry.clear()
+
+
+def teardown_function(_):
+    provider_registry.clear()
+
+
+def test_registry_retrieves_and_searches_with_custom_provider():
+    provider_registry.register("sample", SampleProvider)
+    provider = provider_registry.get("sample")
+    assert isinstance(provider, SampleProvider)
+
+    results = tino_storm.search("query", [], provider="sample")
+    assert results == [{"url": "custom", "snippets": ["ok"], "meta": {}}]


### PR DESCRIPTION
## Summary
- add a simple provider registry for registering search providers
- integrate registry into search provider resolution
- test that custom providers can be registered and used via the registry

## Testing
- `black src/tino_storm/providers/registry.py src/tino_storm/providers/__init__.py src/tino_storm/search.py tests/test_provider_registry.py`
- `ruff check src/tino_storm/providers/registry.py src/tino_storm/providers/__init__.py src/tino_storm/search.py tests/test_provider_registry.py`
- `pytest tests/test_provider_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689bab00f1a083268b68b0f9c91532d6