### PR TITLE
feat: add provider registry

### DIFF
--- a/docs/research_plugin.md
+++ b/docs/research_plugin.md
@@ -27,3 +27,32 @@ export STORM_SEARCH_PROVIDER=my_package.providers.MyProvider
 
 This provider will be loaded automatically whenever `tino_storm.search()` is
 invoked.
+
+### Registering providers programmatically
+
+Providers can also be registered directly in code using the provider
+registry. This is useful when you want to compose multiple providers or make
+them available under friendly names.
+
+```python
+from tino_storm.providers import provider_registry, DefaultProvider
+
+# Register custom provider class or instance under a name
+provider_registry.register("default", DefaultProvider)
+provider_registry.register("my-provider", MyProvider())
+
+# Compose several providers into one
+combined = provider_registry.compose("default", "my-provider")
+results = combined.search("large language models", ["science"])
+```
+
+The `register_provider` decorator can also be used to register a provider
+class:
+
+```python
+from tino_storm.providers import register_provider
+
+@register_provider("my-provider")
+class MyProvider(Provider):
+    ...
+```

--- a/src/tino_storm/providers/__init__.py
+++ b/src/tino_storm/providers/__init__.py
@@ -1,5 +1,13 @@
 from .base import Provider, DefaultProvider, load_provider
 from .parallel import ParallelProvider
+from .registry import ProviderRegistry, provider_registry, register_provider
 
-__all__ = ["Provider", "DefaultProvider", "ParallelProvider", "load_provider"]
-
+__all__ = [
+    "Provider",
+    "DefaultProvider",
+    "ParallelProvider",
+    "load_provider",
+    "ProviderRegistry",
+    "provider_registry",
+    "register_provider",
+]

--- a/src/tino_storm/providers/registry.py
+++ b/src/tino_storm/providers/registry.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, Iterable, Union
+
+from .base import Provider
+
+
+class ProviderRegistry:
+    """Registry mapping names to provider instances."""
+
+    def __init__(self) -> None:
+        self._providers: Dict[str, Provider] = {}
+
+    def register(
+        self, name: str, provider: Union[Provider, type[Provider]]
+    ) -> Provider:
+        """Register *provider* under *name*.
+
+        ``provider`` may be a Provider instance or subclass; subclasses are
+        instantiated with no arguments.
+        """
+
+        if isinstance(provider, type):
+            provider = provider()  # type: ignore[call-arg]
+        self._providers[name] = provider
+        return provider
+
+    def get(self, name: str) -> Provider:
+        """Return the provider registered under *name*."""
+
+        return self._providers[name]
+
+    def compose(self, *names: str) -> Provider:
+        """Compose multiple providers into a single provider.
+
+        The returned provider queries all composed providers and merges their
+        results.
+        """
+
+        providers = [self.get(n) for n in names]
+
+        class _Composite(Provider):
+            def __init__(self, providers: Iterable[Provider]):
+                self.providers = list(providers)
+
+            async def search_async(self, query: str, vaults: Iterable[str], **kwargs):
+                results = await asyncio.gather(
+                    *[p.search_async(query, vaults, **kwargs) for p in self.providers]
+                )
+                merged = []
+                for r in results:
+                    merged.extend(r)
+                return merged
+
+            def search_sync(self, query: str, vaults: Iterable[str], **kwargs):
+                merged = []
+                for p in self.providers:
+                    merged.extend(p.search_sync(query, vaults, **kwargs))
+                return merged
+
+        return _Composite(providers)
+
+    def available(self) -> Dict[str, Provider]:
+        """Return a copy of the registered providers mapping."""
+
+        return dict(self._providers)
+
+
+provider_registry = ProviderRegistry()
+
+
+def register_provider(name: str):
+    """Decorator to register a provider class under *name*."""
+
+    def decorator(cls: Union[type[Provider], Provider]):
+        provider_registry.register(name, cls)
+        return cls
+
+    return decorator


### PR DESCRIPTION
## Summary
- add provider registry allowing registration and composition of providers
- document how to register custom providers programmatically

## Testing
- `black src/tino_storm/providers/registry.py src/tino_storm/providers/__init__.py`
- `ruff check src/tino_storm/providers/registry.py src/tino_storm/providers/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bab0030ac8326bb092e5faf5cbf20