### PR TITLE
refactor: normalize Bing results

### DIFF
--- a/src/tino_storm/providers/base.py
+++ b/src/tino_storm/providers/base.py
@@ -12,6 +12,21 @@ from ..core.rm import BingSearch
 from ..events import ResearchAdded, event_emitter
 
 
+def format_bing_items(items: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Normalize raw Bing results into the internal search format."""
+
+    formatted: List[Dict[str, Any]] = []
+    for item in items:
+        url = item.get("url")
+        if not url:
+            continue
+        snippets = item.get("snippets") or [item.get("description", "")]
+        formatted.append(
+            {"url": url, "snippets": snippets, "meta": {"title": item.get("title")}}
+        )
+    return formatted
+
+
 class Provider(ABC):
     """Base interface for search providers."""
 
@@ -103,16 +118,7 @@ class DefaultProvider(Provider):
         if results:
             return results
         web = self._bing_search(query)
-        formatted = []
-        for item in web:
-            formatted.append(
-                {
-                    "url": item.get("url"),
-                    "snippets": item.get("snippets") or [item.get("description", "")],
-                    "meta": {"title": item.get("title")},
-                }
-            )
-        return formatted
+        return format_bing_items(web)
 
 
 def load_provider(spec: str) -> Provider:

--- a/src/tino_storm/providers/parallel.py
+++ b/src/tino_storm/providers/parallel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import Iterable, List, Dict, Any, Optional
 
-from .base import DefaultProvider
+from .base import DefaultProvider, format_bing_items
 from ..ingest import search_vaults
 from ..retrieval import reciprocal_rank_fusion, score_results, add_posteriors
 
@@ -36,15 +36,7 @@ class ParallelProvider(DefaultProvider):
         rankings: List[List[Dict[str, Any]]] = []
         if vault_res:
             rankings.append(vault_res)
-        formatted: List[Dict[str, Any]] = []
-        for item in bing_res:
-            formatted.append(
-                {
-                    "url": item.get("url"),
-                    "snippets": item.get("snippets") or [item.get("description", "")],
-                    "meta": {"title": item.get("title")},
-                }
-            )
+        formatted = format_bing_items(bing_res)
         if formatted:
             rankings.append(score_results(formatted))
         if not rankings:


### PR DESCRIPTION
## Summary
- add `format_bing_items` helper to normalize Bing result items
- use `format_bing_items` in DefaultProvider and ParallelProvider
- test Bing formatting via DefaultProvider and ParallelProvider

## Testing
- `black src/tino_storm/providers/base.py src/tino_storm/providers/parallel.py tests/test_provider_loading.py`
- `ruff check src/tino_storm/providers/base.py src/tino_storm/providers/parallel.py tests/test_provider_loading.py`
- `pytest tests/test_provider_loading.py`

------
https://chatgpt.com/codex/tasks/task_e_689bb40b20b083269bcaf34d35b86714