### PR TITLE
feat: raise research error on provider failure

### DIFF
--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -9,6 +9,9 @@ from .providers import DefaultProvider, load_provider, Provider
 from .events import ResearchAdded, event_emitter
 
 
+class ResearchError(RuntimeError):
+    """Raised when a search provider fails to complete the query."""
+
 
 def _resolve_provider(provider: Provider | str | None) -> Provider:
     if provider is None:
@@ -63,7 +66,7 @@ async def search_async(
         event_emitter.emit(
             ResearchAdded(topic=query, information_table={"error": str(e)})
         )
-        return []
+        raise ResearchError(str(e)) from e
 
 
 def search(
@@ -100,7 +103,7 @@ def search(
             event_emitter.emit(
                 ResearchAdded(topic=query, information_table={"error": str(e)})
             )
-            return []
+            raise ResearchError(str(e)) from e
 
     return search_async(
         query,

--- a/tests/test_provider_errors.py
+++ b/tests/test_provider_errors.py
@@ -1,5 +1,6 @@
-import tino_storm
+import pytest
 from tino_storm.events import event_emitter, ResearchAdded
+from tino_storm.search import ResearchError, search
 
 
 def test_bing_error_emits_event(monkeypatch):
@@ -74,9 +75,9 @@ def test_search_provider_exception_emits_event(monkeypatch):
         def search_sync(self, *a, **k):
             raise RuntimeError("boom")
 
-    result = tino_storm.search("topic", [], provider=StubProvider())
+    with pytest.raises(ResearchError):
+        search("topic", [], provider=StubProvider())
 
-    assert result == []
     assert len(events) == 1
     assert events[0].topic == "topic"
     assert events[0].information_table["error"] == "boom"

--- a/tests/test_search_errors.py
+++ b/tests/test_search_errors.py
@@ -1,6 +1,9 @@
-from tino_storm.search import search, search_async, Provider
-from tino_storm.events import event_emitter, ResearchAdded
 import asyncio
+
+import pytest
+
+from tino_storm.events import event_emitter, ResearchAdded
+from tino_storm.search import ResearchError, Provider, search, search_async
 
 
 def test_search_sync_error_emits_event(monkeypatch):
@@ -12,9 +15,9 @@ def test_search_sync_error_emits_event(monkeypatch):
         def search_sync(self, *a, **k):
             raise RuntimeError("boom")
 
-    result = search("topic", provider=FailingProvider())
+    with pytest.raises(ResearchError):
+        search("topic", provider=FailingProvider())
 
-    assert result == []
     assert len(events) == 1
     assert events[0].topic == "topic"
     assert events[0].information_table["error"] == "boom"
@@ -33,11 +36,11 @@ def test_search_async_error_emits_event(monkeypatch):
             raise AssertionError("should not be called")
 
     async def run():
-        return await search_async("topic", provider=FailingProvider())
+        await search_async("topic", provider=FailingProvider())
 
-    result = asyncio.run(run())
+    with pytest.raises(ResearchError):
+        asyncio.run(run())
 
-    assert result == []
     assert len(events) == 1
     assert events[0].topic == "topic"
     assert events[0].information_table["error"] == "boom"


### PR DESCRIPTION
## Summary
- add `ResearchError` for failed search provider calls
- raise `ResearchError` after emitting `ResearchAdded` on provider failures
- update tests to expect `ResearchError` while ensuring events emit

## Testing
- `black src/tino_storm/search.py tests/test_search_errors.py tests/test_provider_errors.py`
- `ruff check src/tino_storm/search.py tests/test_search_errors.py tests/test_provider_errors.py`
- `pytest tests/test_search_errors.py tests/test_provider_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_689bb40a5b988326b9f3f6861aefedd5