### PR TITLE
Add provider aggregator and multi-provider resolution

### DIFF
--- a/src/tino_storm/providers/__init__.py
+++ b/src/tino_storm/providers/__init__.py
@@ -1,14 +1,16 @@
 from .base import Provider, DefaultProvider, load_provider
 from .parallel import ParallelProvider
 from .registry import ProviderRegistry, provider_registry, register_provider
+from .aggregator import ProviderAggregator
 
 
 __all__ = [
     "Provider",
     "DefaultProvider",
     "ParallelProvider",
+    "ProviderAggregator",
     "load_provider",
     "ProviderRegistry",
     "provider_registry",
-
+    "register_provider",
 ]

--- a/src/tino_storm/providers/aggregator.py
+++ b/src/tino_storm/providers/aggregator.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable, List, Dict, Any, Optional, Sequence
+
+from .base import Provider, load_provider
+from .registry import provider_registry
+
+
+class ProviderAggregator(Provider):
+    """Aggregate results from multiple providers."""
+
+    def __init__(self, provider_specs: Sequence[str | Provider]):
+        self.providers: List[Provider] = []
+        for spec in provider_specs:
+            if isinstance(spec, Provider):
+                self.providers.append(spec)
+            else:
+                try:
+                    self.providers.append(provider_registry.get(spec))
+                except KeyError:
+                    self.providers.append(load_provider(spec))
+
+    async def search_async(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        results = await asyncio.gather(
+            *[
+                p.search_async(
+                    query,
+                    vaults,
+                    k_per_vault=k_per_vault,
+                    rrf_k=rrf_k,
+                    chroma_path=chroma_path,
+                    vault=vault,
+                )
+                for p in self.providers
+            ]
+        )
+        merged: List[Dict[str, Any]] = []
+        for r in results:
+            merged.extend(r)
+        return merged
+
+    def search_sync(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        merged: List[Dict[str, Any]] = []
+        for p in self.providers:
+            merged.extend(
+                p.search_sync(
+                    query,
+                    vaults,
+                    k_per_vault=k_per_vault,
+                    rrf_k=rrf_k,
+                    chroma_path=chroma_path,
+                    vault=vault,
+                )
+            )
+        return merged

--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -10,13 +10,13 @@ from .providers import (
     load_provider,
     Provider,
     provider_registry,
+    ProviderAggregator,
 )
 from .events import ResearchAdded, event_emitter
 
 
 class ResearchError(RuntimeError):
     """Raised when a search provider fails to complete the query."""
-
 
 
 def _resolve_provider(provider: Provider | str | None) -> Provider:
@@ -26,6 +26,9 @@ def _resolve_provider(provider: Provider | str | None) -> Provider:
             return load_provider(spec)
         return DefaultProvider()
     if isinstance(provider, str):
+        if "," in provider:
+            specs = [p.strip() for p in provider.split(",") if p.strip()]
+            return ProviderAggregator(specs)
         try:
             return provider_registry.get(provider)
         except KeyError:

--- a/tests/test_provider_aggregator.py
+++ b/tests/test_provider_aggregator.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from tino_storm import search as search_fn
+from tino_storm.providers import Provider, provider_registry, ProviderAggregator
+from tino_storm.search import _resolve_provider
+
+
+class DummyProvider(Provider):
+    def __init__(self, name: str):
+        self.name = name
+
+    async def search_async(self, query, vaults, **kwargs):
+        return [{"url": self.name, "snippets": [], "meta": {}}]
+
+    def search_sync(self, query, vaults, **kwargs):
+        return [{"url": self.name, "snippets": [], "meta": {}}]
+
+
+def test_resolve_provider_aggregates_and_runs_concurrently(monkeypatch):
+    monkeypatch.setattr(provider_registry, "_providers", {})
+    provider_registry.register("p1", DummyProvider("p1"))
+    provider_registry.register("p2", DummyProvider("p2"))
+
+    gathered = {}
+    orig_gather = asyncio.gather
+
+    async def gather_wrapper(*tasks, **kwargs):
+        gathered["count"] = len(tasks)
+        return await orig_gather(*tasks, **kwargs)
+
+    monkeypatch.setattr(asyncio, "gather", gather_wrapper)
+
+    provider = _resolve_provider("p1,p2")
+    assert isinstance(provider, ProviderAggregator)
+
+    async def run():
+        return await provider.search_async("q", [])
+
+    results = asyncio.run(run())
+
+    assert gathered["count"] == 2
+    assert {r["url"] for r in results} == {"p1", "p2"}
+
+    sync_results = search_fn("q", [], provider="p1,p2")
+    assert {r["url"] for r in sync_results} == {"p1", "p2"}


### PR DESCRIPTION
## Summary
- introduce `ProviderAggregator` to resolve provider specs and merge search results
- allow comma-separated provider specs in `_resolve_provider`
- test provider aggregation for concurrent execution and combined output

## Testing
- `ruff check src/tino_storm/providers/aggregator.py src/tino_storm/providers/__init__.py src/tino_storm/search.py tests/test_provider_aggregator.py`
- `black --check src/tino_storm/providers/aggregator.py src/tino_storm/providers/__init__.py src/tino_storm/search.py tests/test_provider_aggregator.py`
- `pytest tests/test_provider_aggregator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689bcb9323c48326bf368fc136218189