### PR TITLE
feat: await async event handlers

### DIFF
--- a/src/tino_storm/core/rm.py
+++ b/src/tino_storm/core/rm.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Callable, Union, List
 
+import asyncio
 import backoff
 import dspy
 import requests
@@ -75,8 +76,10 @@ class YouRM(dspy.Retrieve):
                     collected_results.extend(authoritative_results[: self.k])
             except Exception as e:
                 logging.error(f"Error occurs when searching query {query}: {e}")
-                event_emitter.emit(
-                    ResearchAdded(topic=query, information_table={"error": str(e)})
+                asyncio.run(
+                    event_emitter.emit(
+                        ResearchAdded(topic=query, information_table={"error": str(e)})
+                    )
                 )
 
         return collected_results
@@ -179,8 +182,10 @@ class BingSearch(dspy.Retrieve):
             )
         except Exception as e:
             logging.error(f"Error occurs when fetching webpages for {queries}: {e}")
-            event_emitter.emit(
-                ResearchAdded(topic=str(queries), information_table={"error": str(e)})
+            asyncio.run(
+                event_emitter.emit(
+                    ResearchAdded(topic=str(queries), information_table={"error": str(e)})
+                )
             )
             valid_url_to_snippets = {}
         collected_results = []
@@ -417,8 +422,10 @@ class StanfordOvalArxivRM(dspy.Retrieve):
                 collected_results.extend(results)
             except Exception as e:
                 logging.error(f"Error occurs when searching query {query}: {e}")
-                event_emitter.emit(
-                    ResearchAdded(topic=query, information_table={"error": str(e)})
+                asyncio.run(
+                    event_emitter.emit(
+                        ResearchAdded(topic=query, information_table={"error": str(e)})
+                    )
                 )
         return collected_results
 

--- a/src/tino_storm/events.py
+++ b/src/tino_storm/events.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Type, Any, TYPE_CHECKING
+import inspect
 
 if TYPE_CHECKING:
     from .storm_wiki.modules.storm_dataclass import StormInformationTable, StormArticle
@@ -25,14 +26,16 @@ class DocGenerated:
 
 class EventEmitter:
     def __init__(self) -> None:
-        self._subscribers: Dict[Type[Any], List[Callable[[Any], None]]] = {}
+        self._subscribers: Dict[Type[Any], List[Callable[[Any], Any]]] = {}
 
-    def subscribe(self, event_type: Type[Any], handler: Callable[[Any], None]) -> None:
+    def subscribe(self, event_type: Type[Any], handler: Callable[[Any], Any]) -> None:
         self._subscribers.setdefault(event_type, []).append(handler)
 
-    def emit(self, event: Any) -> None:
+    async def emit(self, event: Any) -> None:
         for handler in self._subscribers.get(type(event), []):
-            handler(event)
+            result = handler(event)
+            if inspect.isawaitable(result):
+                await result
 
 
 event_emitter = EventEmitter()

--- a/src/tino_storm/ingest/watcher.py
+++ b/src/tino_storm/ingest/watcher.py
@@ -4,6 +4,7 @@ import os
 import time
 import atexit
 import json
+import asyncio
 from pathlib import Path
 from typing import Any, Optional
 
@@ -163,9 +164,11 @@ class VaultIngestHandler(FileSystemEventHandler):
             metadatas=[{"source": source}],
             ids=[doc_id],
         )
-        event_emitter.emit(
-            ResearchAdded(
-                topic=vault, information_table={"source": source, "doc_id": doc_id}
+        asyncio.run(
+            event_emitter.emit(
+                ResearchAdded(
+                    topic=vault, information_table={"source": source, "doc_id": doc_id}
+                )
             )
         )
 

--- a/src/tino_storm/providers/base.py
+++ b/src/tino_storm/providers/base.py
@@ -92,8 +92,10 @@ class DefaultProvider(Provider):
             return self._bing(query)
         except Exception as e:  # pragma: no cover - network issues
             logging.error(f"Bing search failed for query {query}: {e}")
-            event_emitter.emit(
-                ResearchAdded(topic=query, information_table={"error": str(e)})
+            asyncio.run(
+                event_emitter.emit(
+                    ResearchAdded(topic=query, information_table={"error": str(e)})
+                )
             )
             return []
 

--- a/src/tino_storm/providers/registry.py
+++ b/src/tino_storm/providers/registry.py
@@ -67,6 +67,10 @@ class ProviderRegistry:
 
         return dict(self._providers)
 
+    def clear(self) -> None:
+        """Remove all registered providers."""
+        self._providers.clear()
+
 
 
 provider_registry = ProviderRegistry()

--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -71,8 +71,7 @@ async def search_async(
         )
     except Exception as e:
         logging.error(f"Search failed for query {query}: {e}")
-
-        event_emitter.emit(
+        await event_emitter.emit(
             ResearchAdded(topic=query, information_table={"error": str(e)})
         )
         raise ResearchError(str(e)) from e
@@ -108,9 +107,10 @@ def search(
             )
         except Exception as e:
             logging.error(f"Search failed for query {query}: {e}")
-
-            event_emitter.emit(
-                ResearchAdded(topic=query, information_table={"error": str(e)})
+            asyncio.run(
+                event_emitter.emit(
+                    ResearchAdded(topic=query, information_table={"error": str(e)})
+                )
             )
             raise ResearchError(str(e)) from e
 

--- a/src/tino_storm/storm_wiki/engine.py
+++ b/src/tino_storm/storm_wiki/engine.py
@@ -3,6 +3,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from typing import Union, Literal, Optional
+import asyncio
 
 import dspy
 
@@ -239,8 +240,10 @@ class STORMWikiRunner(Engine):
         information_table.dump_url_to_info(
             os.path.join(self.article_output_dir, "raw_search_results.json")
         )
-        self.event_emitter.emit(
-            ResearchAdded(topic=self.topic, information_table=information_table)
+        asyncio.run(
+            self.event_emitter.emit(
+                ResearchAdded(topic=self.topic, information_table=information_table)
+            )
         )
         return information_table
 
@@ -281,7 +284,11 @@ class STORMWikiRunner(Engine):
         draft_article.dump_reference_to_file(
             os.path.join(self.article_output_dir, "url_to_info.json")
         )
-        self.event_emitter.emit(DocGenerated(topic=self.topic, article=draft_article))
+        asyncio.run(
+            self.event_emitter.emit(
+                DocGenerated(topic=self.topic, article=draft_article)
+            )
+        )
         return draft_article
 
     def run_article_polishing_module(

--- a/tests/test_provider_errors.py
+++ b/tests/test_provider_errors.py
@@ -8,7 +8,11 @@ def test_bing_error_emits_event(monkeypatch):
 
     monkeypatch.setattr(event_emitter, "_subscribers", {})
     events = []
-    event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
+
+    async def handler(e):
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
 
     monkeypatch.setattr("tino_storm.providers.base.search_vaults", lambda *a, **k: [])
 
@@ -32,7 +36,11 @@ def test_bing_error_emits_event(monkeypatch):
 def test_yourm_error_emits_event_once(monkeypatch):
     monkeypatch.setattr(event_emitter, "_subscribers", {})
     events = []
-    event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
+
+    async def handler(e):
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
 
     monkeypatch.setattr("tino_storm.security.audit.log_request", lambda *a, **k: None)
 
@@ -55,7 +63,11 @@ def test_yourm_error_emits_event_once(monkeypatch):
 def test_search_provider_exception_emits_event(monkeypatch):
     monkeypatch.setattr(event_emitter, "_subscribers", {})
     events = []
-    event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
+
+    async def handler(e):
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
 
     import sys
     import types

--- a/tests/test_search_errors.py
+++ b/tests/test_search_errors.py
@@ -9,7 +9,11 @@ from tino_storm.search import ResearchError, Provider, search, search_async
 def test_search_sync_error_emits_event(monkeypatch):
     monkeypatch.setattr(event_emitter, "_subscribers", {})
     events = []
-    event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
+
+    async def handler(e):
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
 
     class FailingProvider(Provider):
         def search_sync(self, *a, **k):
@@ -26,7 +30,11 @@ def test_search_sync_error_emits_event(monkeypatch):
 def test_search_async_error_emits_event(monkeypatch):
     monkeypatch.setattr(event_emitter, "_subscribers", {})
     events = []
-    event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
+
+    async def handler(e):
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
 
     class FailingProvider(Provider):
         async def search_async(self, *a, **k):

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -80,7 +80,11 @@ def test_ingest_text_file(monkeypatch, tmp_path):
     # Reset subscribers and capture events
     monkeypatch.setattr(event_emitter, "_subscribers", {})
     events = []
-    event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
+
+    async def handler(e):
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
 
     monkeypatch.setattr("chromadb.PersistentClient", DummyClient)
     # Ensure the watcher does not enable its test instrumentation
@@ -107,7 +111,11 @@ def test_ingest_text_file(monkeypatch, tmp_path):
 def test_ingest_txt_documents(monkeypatch, tmp_path):
     monkeypatch.setattr(event_emitter, "_subscribers", {})
     events = []
-    event_emitter.subscribe(ResearchAdded, lambda e: events.append(e))
+
+    async def handler(e):
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
 
     monkeypatch.setattr("chromadb.PersistentClient", DummyClient)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)


### PR DESCRIPTION
## Summary
- support awaiting coroutine handlers in EventEmitter
- ensure search and related modules handle async event dispatch
- allow clearing provider registry for tests

## Testing
- `ruff check src/tino_storm/events.py src/tino_storm/search.py src/tino_storm/providers/base.py src/tino_storm/core/rm.py src/tino_storm/ingest/watcher.py src/tino_storm/storm_wiki/engine.py tests/test_provider_errors.py tests/test_search_errors.py tests/test_watcher.py`
- `ruff check src/tino_storm/providers/registry.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bcb93dc908326b9c9477c58e41cd2