### PR TITLE
docs: expand research plugin docs

### DIFF
--- a/docs/research_plugin.md
+++ b/docs/research_plugin.md
@@ -56,3 +56,46 @@ from tino_storm.providers import register_provider
 class MyProvider(Provider):
     ...
 ```
+
+## Custom provider lists
+
+Multiple providers can be combined by passing a comma-separated list to the
+``provider`` argument or the ``STORM_SEARCH_PROVIDER`` environment variable. The
+list is resolved into a ``ProviderAggregator`` which queries each provider and
+merges their results.
+
+```python
+results = await tino_storm.search_async(
+    "large language models",
+    provider="default,my-provider",
+)
+```
+
+## Error handling
+
+When a provider fails to complete a query, ``search`` and ``search_async``
+raise ``ResearchError``. Catch this exception to handle failures gracefully.
+
+```python
+from tino_storm.search import ResearchError, search
+
+try:
+    search("large language models", provider="failing-provider")
+except ResearchError as e:
+    print("Search failed:", e)
+```
+
+## Async event hooks
+
+Tino Storm exposes an ``event_emitter`` for reacting to research-related
+events. Subscribe to ``ResearchAdded`` to receive notifications when research
+is ingested or when searches emit error events.
+
+```python
+from tino_storm.events import event_emitter, ResearchAdded
+
+async def on_research(event: ResearchAdded):
+    print("Research event:", event.topic, event.information_table)
+
+event_emitter.subscribe(ResearchAdded, on_research)
+```

--- a/examples/research_plugin_features.py
+++ b/examples/research_plugin_features.py
@@ -1,0 +1,31 @@
+"""Demonstrate custom providers, ResearchError and async event hooks."""
+
+import asyncio
+
+from tino_storm.events import ResearchAdded, event_emitter
+from tino_storm.providers import Provider, register_provider
+from tino_storm.search import ResearchError, search_async
+
+
+@register_provider("failing-provider")
+class FailingProvider(Provider):
+    async def search_async(self, query, vaults, **kwargs):
+        raise RuntimeError("boom")
+
+
+def handle_research(event: ResearchAdded):
+    print("Research event:", event.topic, event.information_table)
+
+
+event_emitter.subscribe(ResearchAdded, handle_research)
+
+
+async def main() -> None:
+    try:
+        await search_async("large language models", provider="default,failing-provider")
+    except ResearchError as exc:
+        print("Search failed:", exc)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- document custom provider lists, ResearchError and async hooks in research plugin docs
- add example showing provider lists, error handling and event hooks

## Testing
- `pre-commit run --files docs/research_plugin.md examples/research_plugin_features.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bd2be474083268819ad4d36a188b6