### PR TITLE
Refactor search pipeline to return structured results

### DIFF
--- a/src/tino_storm/providers/aggregator.py
+++ b/src/tino_storm/providers/aggregator.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Iterable, List, Dict, Any, Optional, Sequence
+from typing import Iterable, List, Optional, Sequence
 
 from .base import Provider, load_provider
 from .registry import provider_registry
+from ..search_result import ResearchResult
 
 
 class ProviderAggregator(Provider):
@@ -30,7 +31,7 @@ class ProviderAggregator(Provider):
         rrf_k: int = 60,
         chroma_path: Optional[str] = None,
         vault: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+    ) -> List[ResearchResult]:
         results = await asyncio.gather(
             *[
                 p.search_async(
@@ -44,7 +45,7 @@ class ProviderAggregator(Provider):
                 for p in self.providers
             ]
         )
-        merged: List[Dict[str, Any]] = []
+        merged: List[ResearchResult] = []
         for r in results:
             merged.extend(r)
         return merged
@@ -58,8 +59,8 @@ class ProviderAggregator(Provider):
         rrf_k: int = 60,
         chroma_path: Optional[str] = None,
         vault: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
-        merged: List[Dict[str, Any]] = []
+    ) -> List[ResearchResult]:
+        merged: List[ResearchResult] = []
         for p in self.providers:
             merged.extend(
                 p.search_sync(

--- a/src/tino_storm/providers/dummy_async.py
+++ b/src/tino_storm/providers/dummy_async.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Iterable, List, Dict, Any, Optional
+from typing import Iterable, List, Optional
 
 from .base import Provider
+from ..search_result import ResearchResult
 
 
 class DummyAsyncProvider(Provider):
@@ -17,8 +18,10 @@ class DummyAsyncProvider(Provider):
         rrf_k: int = 60,
         chroma_path: Optional[str] = None,
         vault: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
-        return [{"query": query, "vaults": list(vaults)}]
+    ) -> List[ResearchResult]:
+        return [
+            ResearchResult(url="", snippets=[], meta={"query": query, "vaults": list(vaults)})
+        ]
 
     def search_sync(
         self,
@@ -29,5 +32,5 @@ class DummyAsyncProvider(Provider):
         rrf_k: int = 60,
         chroma_path: Optional[str] = None,
         vault: Optional[str] = None,
-    ) -> List[Dict[str, Any]]:
+    ) -> List[ResearchResult]:
         raise NotImplementedError("DummyAsyncProvider only implements search_async")

--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -1,9 +1,8 @@
 import asyncio
-from typing import Iterable, List, Dict, Any, Optional
-from pathlib import Path
-
-import os
 import logging
+import os
+from pathlib import Path
+from typing import Iterable, List, Optional
 
 from .providers import (
     DefaultProvider,
@@ -13,6 +12,7 @@ from .providers import (
     ProviderAggregator,
 )
 from .events import ResearchAdded, event_emitter
+from .search_result import ResearchResult
 
 
 class ResearchError(RuntimeError):
@@ -56,7 +56,7 @@ async def search_async(
     chroma_path: Optional[str] = None,
     vault: Optional[str] = None,
     provider: Provider | str | None = None,
-) -> List[Dict[str, Any]]:
+) -> List[ResearchResult]:
     """Asynchronously query ``vaults`` using the configured provider."""
 
     if vaults is None:
@@ -89,7 +89,7 @@ def search(
     chroma_path: Optional[str] = None,
     vault: Optional[str] = None,
     provider: Provider | str | None = None,
-):
+) -> List[ResearchResult]:
     """Query ``vaults`` synchronously or return an awaitable when in an event loop."""
 
     if vaults is None:

--- a/src/tino_storm/search_result.py
+++ b/src/tino_storm/search_result.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class ResearchResult:
+    """Structured result returned from research providers."""
+
+    url: str
+    snippets: List[str]
+    meta: Dict[str, Any] = field(default_factory=dict)
+    summary: Optional[str] = None
+
+
+def as_research_result(data: Dict[str, Any]) -> ResearchResult:
+    """Convert a mapping to ``ResearchResult`` ignoring extra keys."""
+
+    return ResearchResult(
+        url=data.get("url", ""),
+        snippets=data.get("snippets", []),
+        meta=data.get("meta", {}),
+        summary=data.get("summary"),
+    )

--- a/tests/test_provider_aggregator.py
+++ b/tests/test_provider_aggregator.py
@@ -2,6 +2,7 @@ import asyncio
 
 from tino_storm import search as search_fn
 from tino_storm.providers import Provider, provider_registry, ProviderAggregator
+from tino_storm.search_result import ResearchResult
 from tino_storm.search import _resolve_provider
 
 
@@ -10,10 +11,10 @@ class DummyProvider(Provider):
         self.name = name
 
     async def search_async(self, query, vaults, **kwargs):
-        return [{"url": self.name, "snippets": [], "meta": {}}]
+        return [ResearchResult(url=self.name, snippets=[], meta={})]
 
     def search_sync(self, query, vaults, **kwargs):
-        return [{"url": self.name, "snippets": [], "meta": {}}]
+        return [ResearchResult(url=self.name, snippets=[], meta={})]
 
 
 def test_resolve_provider_aggregates_and_runs_concurrently(monkeypatch):
@@ -39,7 +40,7 @@ def test_resolve_provider_aggregates_and_runs_concurrently(monkeypatch):
     results = asyncio.run(run())
 
     assert gathered["count"] == 2
-    assert {r["url"] for r in results} == {"p1", "p2"}
+    assert {r.url for r in results} == {"p1", "p2"}
 
     sync_results = search_fn("q", [], provider="p1,p2")
-    assert {r["url"] for r in sync_results} == {"p1", "p2"}
+    assert {r.url for r in sync_results} == {"p1", "p2"}

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,5 +1,6 @@
 import tino_storm
 from tino_storm.providers import Provider, provider_registry
+from tino_storm.search_result import ResearchResult
 
 
 class SampleProvider(Provider):
@@ -12,8 +13,8 @@ class SampleProvider(Provider):
         rrf_k=60,
         chroma_path=None,
         vault=None,
-    ):
-        return [{"url": "custom", "snippets": ["ok"], "meta": {}}]
+    ) -> list[ResearchResult]:
+        return [ResearchResult(url="custom", snippets=["ok"], meta={})]
 
 
 def setup_function(_):
@@ -30,4 +31,4 @@ def test_registry_retrieves_and_searches_with_custom_provider():
     assert isinstance(provider, SampleProvider)
 
     results = tino_storm.search("query", [], provider="sample")
-    assert results == [{"url": "custom", "snippets": ["ok"], "meta": {}}]
+    assert results == [ResearchResult(url="custom", snippets=["ok"], meta={})]

--- a/tests/test_search_function.py
+++ b/tests/test_search_function.py
@@ -2,6 +2,7 @@ import asyncio
 import importlib
 
 import tino_storm
+from tino_storm.search_result import ResearchResult
 
 
 def test_search_sync(monkeypatch):
@@ -30,7 +31,7 @@ def test_search_sync(monkeypatch):
                 chroma_path,
                 vault,
             )
-            return ["ok"]
+            return [ResearchResult(url="ok", snippets=[], meta={})]
 
     fake_provider = FakeProvider()
     monkeypatch.setattr(
@@ -42,7 +43,7 @@ def test_search_sync(monkeypatch):
 
     result = tino_storm.search("q", ["v"])
 
-    assert result == ["ok"]
+    assert result == [ResearchResult(url="ok", snippets=[], meta={})]
     assert called["args"] == ("q", ["v"], 5, 60, None, None)
 
 
@@ -76,7 +77,7 @@ def test_search_async(monkeypatch):
                 chroma_path,
                 vault,
             )
-            return ["async"]
+            return [ResearchResult(url="async", snippets=[], meta={})]
 
     monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
     fake_provider = FakeProvider()
@@ -91,7 +92,7 @@ def test_search_async(monkeypatch):
 
     result = asyncio.run(_run())
 
-    assert result == ["async"]
+    assert result == [ResearchResult(url="async", snippets=[], meta={})]
     assert called["thread"]
     assert called["args"] == ("q", ["v"], 5, 60, None, None)
 
@@ -121,7 +122,7 @@ def test_search_awaits_provider_coroutine(monkeypatch):
                 chroma_path,
                 vault,
             )
-            return ["awaited"]
+            return [ResearchResult(url="awaited", snippets=[], meta={})]
 
         def search_sync(self, *a, **k):
             called["sync"] = True
@@ -139,7 +140,7 @@ def test_search_awaits_provider_coroutine(monkeypatch):
 
     result = asyncio.run(_run())
 
-    assert result == ["awaited"]
+    assert result == [ResearchResult(url="awaited", snippets=[], meta={})]
     assert called["args"] == ("q", ["v"], 5, 60, None, None)
     assert "sync" not in called
 
@@ -173,7 +174,7 @@ def test_search_without_vaults_uses_default(monkeypatch):
                 chroma_path,
                 vault,
             )
-            return ["ok"]
+            return [ResearchResult(url="ok", snippets=[], meta={})]
 
     monkeypatch.setattr(search_mod, "list_vaults", fake_list_vaults)
     fake_provider = FakeProvider()
@@ -185,6 +186,6 @@ def test_search_without_vaults_uses_default(monkeypatch):
 
     result = tino_storm.search("q")
 
-    assert result == ["ok"]
+    assert result == [ResearchResult(url="ok", snippets=[], meta={})]
     assert called["list"]
     assert called["args"] == ("q", ["a", "b"], 5, 60, None, None)


### PR DESCRIPTION
## Summary
- add `ResearchResult` dataclass and helper
- refactor search and providers to return `List[ResearchResult]`
- update tests for new result type

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ccd82bc988326ab5f23f988cacff8