### PR TITLE
Handle provider failures in aggregator

### DIFF
--- a/tests/test_provider_aggregator.py
+++ b/tests/test_provider_aggregator.py
@@ -1,7 +1,8 @@
 import asyncio
 
-from tino_storm import search as search_fn
-from tino_storm.providers import Provider, provider_registry, ProviderAggregator
+from tino_storm.providers.base import Provider
+from tino_storm.providers.registry import provider_registry
+from tino_storm.providers.aggregator import ProviderAggregator
 from tino_storm.search import _resolve_provider
 
 
@@ -14,6 +15,16 @@ class DummyProvider(Provider):
 
     def search_sync(self, query, vaults, **kwargs):
         return [{"url": self.name, "snippets": [], "meta": {}}]
+
+
+class FailingProvider(Provider):
+    name = "failing"
+
+    async def search_async(self, query, vaults, **kwargs):
+        raise RuntimeError("boom")
+
+    def search_sync(self, query, vaults, **kwargs):
+        raise RuntimeError("boom")
 
 
 def test_resolve_provider_aggregates_and_runs_concurrently(monkeypatch):
@@ -41,5 +52,22 @@ def test_resolve_provider_aggregates_and_runs_concurrently(monkeypatch):
     assert gathered["count"] == 2
     assert {r["url"] for r in results} == {"p1", "p2"}
 
-    sync_results = search_fn("q", [], provider="p1,p2")
+    sync_results = provider.search_sync("q", [])
     assert {r["url"] for r in sync_results} == {"p1", "p2"}
+
+
+def test_aggregator_skips_failures(monkeypatch):
+    monkeypatch.setattr(provider_registry, "_providers", {})
+    provider_registry.register("good", DummyProvider("good"))
+    provider_registry.register("bad", FailingProvider())
+
+    provider = _resolve_provider("good,bad")
+
+    async def run_async():
+        return await provider.search_async("q", [])
+
+    async_results = asyncio.run(run_async())
+    assert {r["url"] for r in async_results} == {"good"}
+
+    sync_results = provider.search_sync("q", [])
+    assert {r["url"] for r in sync_results} == {"good"}


### PR DESCRIPTION
## Summary
- skip failed providers in ProviderAggregator using `asyncio.gather(..., return_exceptions=True)`
- guard synchronous provider calls with try/except and log exceptions
- test that ProviderAggregator continues when a provider fails

## Testing
- `ruff check src/tino_storm/providers/aggregator.py tests/test_provider_aggregator.py`
- `black --check src/tino_storm/providers/aggregator.py tests/test_provider_aggregator.py`
- `pytest tests/test_provider_aggregator.py`


------
https://chatgpt.com/codex/tasks/task_e_689ccd82a6f48326b5f1f3a6de1c1354