### PR TITLE
Add Docs Hub provider for local docs search

### DIFF
--- a/src/tino_storm/providers/__init__.py
+++ b/src/tino_storm/providers/__init__.py
@@ -2,6 +2,7 @@ from .base import Provider, DefaultProvider, load_provider
 from .parallel import ParallelProvider
 from .registry import ProviderRegistry, provider_registry, register_provider
 from .aggregator import ProviderAggregator
+from .docs_hub import DocsHubProvider
 
 
 __all__ = [
@@ -9,6 +10,7 @@ __all__ = [
     "DefaultProvider",
     "ParallelProvider",
     "ProviderAggregator",
+    "DocsHubProvider",
     "load_provider",
     "ProviderRegistry",
     "provider_registry",

--- a/src/tino_storm/providers/docs_hub.py
+++ b/src/tino_storm/providers/docs_hub.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from .base import Provider
+from .registry import register_provider
+from ..search_result import ResearchResult, as_research_result
+from ..ingest import search_vaults
+
+
+@register_provider("docs_hub")
+class DocsHubProvider(Provider):
+    """Provider that queries the local Docs/knowledge index."""
+
+    def search_sync(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[ResearchResult]:
+        """Synchronously search the local docs index."""
+        raw_results = search_vaults(
+            query,
+            vaults,
+            k_per_vault=k_per_vault,
+            rrf_k=rrf_k,
+            chroma_path=chroma_path,
+            vault=vault,
+        )
+        return [as_research_result(r) for r in raw_results]

--- a/tests/test_docs_hub_provider.py
+++ b/tests/test_docs_hub_provider.py
@@ -1,0 +1,74 @@
+import importlib.machinery
+import sys
+import types
+
+pytesseract = types.ModuleType("pytesseract")
+pytesseract.__spec__ = importlib.machinery.ModuleSpec("pytesseract", loader=None)
+pytesseract.image_to_string = lambda *a, **k: ""
+sys.modules.setdefault("pytesseract", pytesseract)
+
+import asyncio  # noqa: E402
+
+from tino_storm.providers.registry import provider_registry  # noqa: E402
+
+
+class DummyCollection:
+    def __init__(self, results):
+        self._results = results
+        self.last_query_kwargs = None
+
+    def query(self, query_texts=None, n_results=0, **kwargs):
+        self.last_query_kwargs = {"query_texts": query_texts, "n_results": n_results}
+        docs = [d for d, _ in self._results][:n_results]
+        metas = [m for _, m in self._results][:n_results]
+        return {"documents": [docs], "metadatas": [metas]}
+
+
+class DummyClient:
+    def __init__(self, collections):
+        self.collections = collections
+
+    def get_or_create_collection(self, name):
+        return self.collections[name]
+
+
+def _setup_index(monkeypatch):
+    client = DummyClient(
+        {
+            "docs_vault": DummyCollection(
+                [("A snippet", {"source": "docA"}), ("B snippet", {"source": "docB"})]
+            )
+        }
+    )
+    monkeypatch.setattr("chromadb.PersistentClient", lambda *a, **k: client)
+    monkeypatch.setattr(
+        "tino_storm.ingest.search.get_passphrase", lambda vault=None: None
+    )
+    monkeypatch.setattr("tino_storm.ingest.search.score_results", lambda x: x)
+    return client
+
+
+def test_docs_hub_provider_registration(monkeypatch):
+    monkeypatch.setattr(provider_registry, "_providers", {})
+    import importlib
+    import tino_storm.providers.docs_hub as docs_hub
+
+    importlib.reload(docs_hub)
+    assert isinstance(provider_registry.get("docs_hub"), docs_hub.DocsHubProvider)
+
+
+def test_docs_hub_provider_search(monkeypatch):
+    client = _setup_index(monkeypatch)
+
+    from tino_storm.providers.docs_hub import DocsHubProvider
+
+    provider = DocsHubProvider()
+    results = provider.search_sync("q", ["docs_vault"], k_per_vault=2, rrf_k=5)
+    assert [r.url for r in results] == ["docA", "docB"]
+    assert client.collections["docs_vault"].last_query_kwargs["query_texts"] == ["q"]
+
+    async def run():
+        return await provider.search_async("q", ["docs_vault"], k_per_vault=2, rrf_k=5)
+
+    async_results = asyncio.run(run())
+    assert [r.url for r in async_results] == ["docA", "docB"]


### PR DESCRIPTION
## Summary
- implement `DocsHubProvider` to query local docs index and register as `docs_hub`
- expose `DocsHubProvider` via providers package
- test provider registration and search against sample doc index

## Testing
- `black src/tino_storm/providers/docs_hub.py src/tino_storm/providers/__init__.py tests/test_docs_hub_provider.py`
- `ruff check src/tino_storm/providers/docs_hub.py src/tino_storm/providers/__init__.py tests/test_docs_hub_provider.py`
- `pytest tests/test_docs_hub_provider.py`

------
https://chatgpt.com/codex/tasks/task_e_689cd7f34b408326bbd829b3e4496fde