### PR TITLE
Add asynchronous Bing search provider

### DIFF
--- a/src/tino_storm/providers/bing_async.py
+++ b/src/tino_storm/providers/bing_async.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+from typing import Iterable, List, Optional
+
+import httpx
+
+from .base import Provider, format_bing_items
+from .registry import register_provider
+from ..search_result import ResearchResult, as_research_result
+
+BING_ENDPOINT = "https://api.bing.microsoft.com/v7.0/search"
+
+
+@register_provider("bing_async")
+class BingAsyncProvider(Provider):
+    """Asynchronous Bing search provider using httpx."""
+
+    async def search_async(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[ResearchResult]:
+        api_key = os.environ.get("BING_SEARCH_API_KEY")
+        if not api_key:
+            return []
+        headers = {"Ocp-Apim-Subscription-Key": api_key}
+        params = {"q": query, "count": k_per_vault}
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(BING_ENDPOINT, params=params, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        items = data.get("webPages", {}).get("value", [])
+        # Map Bing's ``snippet`` field to ``description`` expected by
+        # ``format_bing_items`` for snippet normalization.
+        normalized = []
+        for item in items:
+            if "snippet" in item and "description" not in item and "snippets" not in item:
+                item = {**item, "description": item["snippet"]}
+            if "name" in item and "title" not in item:
+                item = {**item, "title": item["name"]}
+            normalized.append(item)
+        formatted = format_bing_items(normalized)
+        return [as_research_result(r) for r in formatted]
+
+    def search_sync(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[ResearchResult]:
+        raise NotImplementedError("BingAsyncProvider only implements search_async")

--- a/tests/test_bing_async_provider.py
+++ b/tests/test_bing_async_provider.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+
+import httpx
+
+import tino_storm.providers.bing_async  # noqa: F401 ensures provider registration
+from tino_storm.providers import provider_registry
+from tino_storm.providers.bing_async import BingAsyncProvider
+
+
+def test_bing_async_provider_fetches(monkeypatch):
+    os.environ["BING_SEARCH_API_KEY"] = "test-key"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Ocp-Apim-Subscription-Key"] == "test-key"
+        assert request.url.params["q"] == "test query"
+        data = {"webPages": {"value": [{"url": "https://example.com", "snippet": "Example snippet", "name": "Example"}]}}
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(handler)
+    original_async_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx, "AsyncClient", lambda *a, **k: original_async_client(transport=transport)
+    )
+
+    provider = provider_registry.get("bing_async")
+    results = asyncio.run(provider.search_async("test query", []))
+    assert len(results) == 1
+    result = results[0]
+    assert result.url == "https://example.com"
+    assert result.snippets == ["Example snippet"]
+    assert result.meta["title"] == "Example"
+
+
+def test_bing_async_provider_no_key(monkeypatch):
+    monkeypatch.delenv("BING_SEARCH_API_KEY", raising=False)
+    provider = BingAsyncProvider()
+    results = asyncio.run(provider.search_async("irrelevant", []))
+    assert results == []

--- a/tests/test_provider_aggregator.py
+++ b/tests/test_provider_aggregator.py
@@ -3,8 +3,8 @@ import asyncio
 from tino_storm.providers.base import Provider
 from tino_storm.providers.registry import provider_registry
 from tino_storm.providers.aggregator import ProviderAggregator
-
 from tino_storm.search import _resolve_provider
+from tino_storm.search_result import ResearchResult
 
 
 class DummyProvider(Provider):
@@ -15,7 +15,7 @@ class DummyProvider(Provider):
         return [ResearchResult(url=self.name, snippets=[], meta={})]
 
     def search_sync(self, query, vaults, **kwargs):
-        return [ResearchResult(url=self.name, snippets=[], meta={})]
+        return [{"url": self.name, "snippets": [], "meta": {}}]
 
 
 class FailingProvider(Provider):
@@ -68,7 +68,7 @@ def test_aggregator_skips_failures(monkeypatch):
         return await provider.search_async("q", [])
 
     async_results = asyncio.run(run_async())
-    assert {r["url"] for r in async_results} == {"good"}
+    assert {r.url for r in async_results} == {"good"}
 
     sync_results = provider.search_sync("q", [])
     assert {r["url"] for r in sync_results} == {"good"}


### PR DESCRIPTION
## Summary
- add `BingAsyncProvider` using `httpx.AsyncClient` and Bing Search API
- exercise provider with mocked HTTP responses
- fix provider aggregator tests to import `ResearchResult` and handle dict results

## Testing
- `python -m ruff check src/tino_storm/providers/bing_async.py tests/test_bing_async_provider.py tests/test_provider_aggregator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd7f2609083268efbafaf5e108655