### PR TITLE
Load providers via entry points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
 [project.scripts]
 tino-storm = "tino_storm.cli:main"
 
+[project.entry-points."tino_storm.providers"]
+bing_async = "tino_storm.providers.bing_async:BingAsyncProvider"
+
 [project.optional-dependencies]
 scrapers = [
     "snscrape",

--- a/src/tino_storm/providers/registry.py
+++ b/src/tino_storm/providers/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from importlib.metadata import entry_points
 from typing import Dict, Iterable, Union
 
 
@@ -12,6 +13,17 @@ class ProviderRegistry:
 
     def __init__(self) -> None:
         self._providers: Dict[str, Provider] = {}
+        self._load_entrypoint_providers()
+
+    def _load_entrypoint_providers(self) -> None:
+        """Load providers exposed via Python entry points."""
+
+        for ep in entry_points(group="tino_storm.providers"):
+            try:
+                provider = ep.load()
+            except Exception:
+                continue
+            self.register(ep.name, provider)
 
     def register(
         self, name: str, provider: Union[Provider, type[Provider]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -580,6 +580,9 @@ for _missing in [
                 return ""
 
             pytesseract_mod.image_to_string = image_to_string
+            pytesseract_mod.__spec__ = importlib.machinery.ModuleSpec(
+                "pytesseract", loader=None
+            )
             module = pytesseract_mod
         elif _missing == "praw":
             praw_mod = types.ModuleType("praw")

--- a/tests/test_provider_entrypoints.py
+++ b/tests/test_provider_entrypoints.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+from tino_storm.providers import Provider
+from tino_storm.providers.registry import ProviderRegistry
+
+
+class DummyProvider(Provider):
+    async def search_async(self, query, vaults, **kwargs):  # pragma: no cover - simple stub
+        return []
+
+    def search_sync(self, query, vaults, **kwargs):  # pragma: no cover - simple stub
+        return []
+
+
+def test_loads_providers_from_entry_points(monkeypatch):
+    dummy_ep = SimpleNamespace(name="dummy", load=lambda: DummyProvider)
+
+    def fake_entry_points(*, group):
+        assert group == "tino_storm.providers"
+        return [dummy_ep]
+
+    monkeypatch.setattr(
+        "tino_storm.providers.registry.entry_points", fake_entry_points
+    )
+    registry = ProviderRegistry()
+    assert isinstance(registry.get("dummy"), DummyProvider)


### PR DESCRIPTION
## Summary
- Load providers registered under the `tino_storm.providers` entry point group during registry initialization
- Expose `bing_async` provider via packaging entry points
- Test entry point loading via a dummy provider
- Define a `ModuleSpec` for the `pytesseract` test stub so importlib metadata lookup succeeds

## Testing
- `ruff check tests/conftest.py src/tino_storm/providers/registry.py tests/test_provider_entrypoints.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d00b9dda4832697bb20cee7fa4c8d