### PR TITLE
Handle event handler failures gracefully

### DIFF
--- a/src/tino_storm/events.py
+++ b/src/tino_storm/events.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Type, Any, TYPE_CHECKING
+from typing import Callable, Dict, List, Type, Any, TYPE_CHECKING, Optional
 import inspect
+import logging
 
 if TYPE_CHECKING:
     from .storm_wiki.modules.storm_dataclass import StormInformationTable, StormArticle
@@ -31,11 +32,40 @@ class EventEmitter:
     def subscribe(self, event_type: Type[Any], handler: Callable[[Any], Any]) -> None:
         self._subscribers.setdefault(event_type, []).append(handler)
 
-    async def emit(self, event: Any) -> None:
+    async def emit(
+        self,
+        event: Any,
+        on_error: Optional[
+            Callable[[Callable[[Any], Any], Any, Exception], None]
+        ] = None,
+    ) -> None:
+        """Emit an event to all subscribed handlers.
+
+        Each handler is invoked safely. If a handler raises an exception,
+        the error is logged and remaining handlers continue to run. A custom
+        ``on_error`` callback can be provided to override the default logging
+        behavior.
+
+        Args:
+            event: The event instance to emit.
+            on_error: Optional callback ``(handler, event, exception)`` used
+                for custom error logging.
+        """
         for handler in self._subscribers.get(type(event), []):
-            result = handler(event)
-            if inspect.isawaitable(result):
-                await result
+            try:
+                result = handler(event)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:  # noqa: BLE001
+                if on_error is not None:
+                    on_error(handler, event, exc)
+                else:
+                    handler_name = getattr(handler, "__name__", repr(handler))
+                    logging.exception(
+                        "Error in handler %s for event %s",
+                        handler_name,
+                        type(event).__name__,
+                    )
 
 
 event_emitter = EventEmitter()


### PR DESCRIPTION
## Summary
- protect event handlers from crashing the event loop by wrapping each call in try/except
- allow custom error logging via an optional `on_error` callback

## Testing
- `black src/tino_storm/events.py`
- `ruff check src/tino_storm/events.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d39a3ae7483269655af794bfe55c8