### PR TITLE
Add optional LLM summaries to search results

### DIFF
--- a/docs/research_plugin.md
+++ b/docs/research_plugin.md
@@ -24,8 +24,10 @@ asyncio.run(main())
 ```
 
 The search API returns a list of `ResearchResult` objects containing the URL,
-text snippets, optional metadata and an optional summary from the retrieved
-documents.
+text snippets, optional metadata and a short summary from the retrieved
+documents. By default the first snippet is used as the summary. If the
+`STORM_SUMMARY_MODEL` environment variable is set, that model will be invoked
+to generate a one-sentence summary for each result.
 
 ```python
 from tino_storm.search_result import ResearchResult

--- a/tests/test_provider_loading.py
+++ b/tests/test_provider_loading.py
@@ -109,5 +109,5 @@ def test_default_provider_formats_bing(monkeypatch):
     )
     results = provider.search_sync("q", [])
     assert results == [
-        ResearchResult(url="u", snippets=["d"], meta={"title": "t"})
+        ResearchResult(url="u", snippets=["d"], meta={"title": "t"}, summary="d")
     ]


### PR DESCRIPTION
## Summary
- populate `summary` in `ResearchResult` using first snippet or optional LLM call
- document `STORM_SUMMARY_MODEL` environment variable to enable LLM summarization

## Testing
- `ruff check src/tino_storm/providers/base.py tests/test_provider_loading.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4097c42483269756a28ffae32059