### PR TITLE
Enable non-blocking DocsHub search and async registry aggregation

### DIFF
--- a/src/tino_storm/providers/docs_hub.py
+++ b/src/tino_storm/providers/docs_hub.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Iterable, List, Optional
 
 from .base import Provider
@@ -11,6 +12,28 @@ from ..ingest import search_vaults
 @register_provider("docs_hub")
 class DocsHubProvider(Provider):
     """Provider that queries the local Docs/knowledge index."""
+
+    async def search_async(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[ResearchResult]:
+        """Asynchronously search the local docs index without blocking."""
+        raw_results = await asyncio.to_thread(
+            search_vaults,
+            query,
+            vaults,
+            k_per_vault=k_per_vault,
+            rrf_k=rrf_k,
+            chroma_path=chroma_path,
+            vault=vault,
+        )
+        return [as_research_result(r) for r in raw_results]
 
     def search_sync(
         self,


### PR DESCRIPTION
## Summary
- add true async search to `DocsHubProvider` using `asyncio.to_thread`
- allow `ProviderRegistry.compose` to aggregate providers concurrently and log failures

## Testing
- `black src/tino_storm/providers/docs_hub.py src/tino_storm/providers/registry.py`
- `ruff check src/tino_storm/providers/docs_hub.py src/tino_storm/providers/registry.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d409742f48326b30a9ba84b5e7e1e