### PR TITLE
Add tests for DefaultProvider summary generation

### DIFF
--- a/tests/test_default_provider_summary.py
+++ b/tests/test_default_provider_summary.py
@@ -1,0 +1,32 @@
+from tino_storm.providers import DefaultProvider
+
+
+def test_search_sync_populates_summary_without_model(monkeypatch):
+    monkeypatch.delenv("STORM_SUMMARY_MODEL", raising=False)
+    monkeypatch.setattr(
+        "tino_storm.providers.base.search_vaults",
+        lambda *a, **k: [{"url": "u", "snippets": ["s"], "meta": {}}],
+    )
+
+    provider = DefaultProvider()
+    results = provider.search_sync("q", [])
+
+    assert results[0].summary == "s"
+
+
+def test_search_sync_uses_summarizer_when_model_set(monkeypatch):
+    monkeypatch.setenv("STORM_SUMMARY_MODEL", "model")
+    monkeypatch.setattr(
+        "tino_storm.providers.base.search_vaults",
+        lambda *a, **k: [{"url": "u", "snippets": ["s"], "meta": {}}],
+    )
+
+    provider = DefaultProvider()
+
+    def fake_summarizer(_prompt):
+        return ["llm summary"]
+
+    monkeypatch.setattr(provider, "_get_summarizer", lambda: fake_summarizer)
+    results = provider.search_sync("q", [])
+
+    assert results[0].summary == "llm summary"


### PR DESCRIPTION
## Summary
- add tests ensuring DefaultProvider.search_sync populates summaries from snippets
- verify summarization uses a provided model when configured

## Testing
- `ruff check tests/test_default_provider_summary.py`
- `pytest tests/test_default_provider_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_689f331145c88326888749914dbc1958