### PR TITLE
Add timeout handling and event emission for retrieval failures

### DIFF
--- a/tests/test_rm_timeouts.py
+++ b/tests/test_rm_timeouts.py
@@ -1,0 +1,54 @@
+import requests
+import pytest
+
+from tino_storm.core.rm import BingSearch, YouRM
+from tino_storm.events import ResearchAdded, event_emitter
+
+
+def test_yourm_timeout_emits_event(monkeypatch):
+    monkeypatch.setattr(event_emitter, "_subscribers", {})
+    events = []
+
+    async def handler(e):
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
+
+    def mock_get(*a, **k):
+        raise requests.Timeout("boom")
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    rm = YouRM(ydc_api_key="fake")
+
+    with pytest.raises(requests.Timeout):
+        rm.forward("topic")
+
+    assert len(events) == 1
+    assert events[0].topic == "topic"
+    assert events[0].information_table["error"] == "boom"
+
+
+def test_bing_timeout_emits_event(monkeypatch):
+    monkeypatch.setattr(event_emitter, "_subscribers", {})
+    events = []
+
+    async def handler(e):
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
+
+    def mock_get(*a, **k):
+        raise requests.Timeout("boom")
+
+    monkeypatch.setattr(requests, "get", mock_get)
+
+    rm = BingSearch(bing_search_api_key="fake")
+
+    result = rm.forward("topic")
+
+    assert result == []
+    assert len(events) == 1
+    assert events[0].topic == "topic"
+    assert events[0].information_table["error"] == "boom"
+


### PR DESCRIPTION
## Summary
- add request timeouts and RequestException handling to YouRM and BingSearch retrievers
- emit ResearchAdded events on request failures and return empty results or raise
- test timeouts for both retrievers with mocked requests and event emission verification

## Testing
- `ruff check src/tino_storm/core/rm.py tests/test_rm_timeouts.py`
- `pytest tests/test_rm_timeouts.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3a9cb9708326940c8bce7fd849a2