### PR TITLE
Handle async-only providers in search

### DIFF
--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -100,14 +100,26 @@ def search(
     except RuntimeError:
         provider = _resolve_provider(provider)
         try:
-            return provider.search_sync(
-                query,
-                vaults,
-                k_per_vault=k_per_vault,
-                rrf_k=rrf_k,
-                chroma_path=chroma_path,
-                vault=vault,
-            )
+            try:
+                return provider.search_sync(
+                    query,
+                    vaults,
+                    k_per_vault=k_per_vault,
+                    rrf_k=rrf_k,
+                    chroma_path=chroma_path,
+                    vault=vault,
+                )
+            except NotImplementedError:
+                return asyncio.run(
+                    provider.search_async(
+                        query,
+                        vaults,
+                        k_per_vault=k_per_vault,
+                        rrf_k=rrf_k,
+                        chroma_path=chroma_path,
+                        vault=vault,
+                    )
+                )
         except Exception as e:
             logging.error(f"Search failed for query {query}: {e}")
             asyncio.run(


### PR DESCRIPTION
## Summary
- fall back to asyncio.run when provider lacks search_sync
- test BingAsyncProvider uses asyncio.run outside an event loop

## Testing
- `black --check src/tino_storm/search.py tests/test_search_function.py`
- `ruff check src/tino_storm/search.py tests/test_search_function.py`
- `pytest tests/test_search_function.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f3a9d3c448326b3f179e47c106c1f