### PR TITLE
feat: add retrieval optional dependencies

### DIFF
--- a/docs/research_plugin.md
+++ b/docs/research_plugin.md
@@ -7,6 +7,7 @@ extras to pull in additional features:
 ```bash
 pip install tino-storm[research]  # FastAPI server and filesystem watcher
 pip install tino-storm[scrapers]  # ingestion helpers for social platforms
+pip install tino-storm[retrieval] # semantic search and vector DB helpers
 ```
 
 The synchronous helper automatically delegates to `search_async()` when an event

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,8 @@ requires-python = ">=3.10"
 dependencies = [
     "dspy_ai==2.4.9",
     "wikipedia==1.4.0",
-    "sentence-transformers",
     "toml",
-    "langchain-text-splitters",
     "trafilatura",
-    "langchain-huggingface",
-    "qdrant-client",
-    "langchain-qdrant",
     "numpy==1.26.4",
     "litellm==1.59.3",
     "pytz",
@@ -41,6 +36,13 @@ research = [
     "uvicorn>=0.29.0",
     "watchdog",
     "knowledge-storm",
+]
+retrieval = [
+    "sentence-transformers",
+    "langchain-text-splitters",
+    "langchain-huggingface",
+    "qdrant-client",
+    "langchain-qdrant",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- move sentence-transformers, langchain packages, and qdrant-client into a new optional `retrieval` extras group
- document installation of `tino-storm[retrieval]`

## Testing
- `python -m pip install -e '.[retrieval]'`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f3eaa85a883269f29697322a19b67