### PR TITLE
Add unsubscribe method for events

### DIFF
--- a/src/tino_storm/events.py
+++ b/src/tino_storm/events.py
@@ -32,6 +32,22 @@ class EventEmitter:
     def subscribe(self, event_type: Type[Any], handler: Callable[[Any], Any]) -> None:
         self._subscribers.setdefault(event_type, []).append(handler)
 
+    def unsubscribe(self, event_type: Type[Any], handler: Callable[[Any], Any]) -> None:
+        """Remove a previously registered handler.
+
+        The handler is removed from the subscriber list for ``event_type``.
+        If the handler or event type is not registered, the call is a no-op.
+        """
+        handlers = self._subscribers.get(event_type)
+        if not handlers:
+            return
+        try:
+            handlers.remove(handler)
+        except ValueError:
+            return
+        if not handlers:
+            del self._subscribers[event_type]
+
     async def emit(
         self,
         event: Any,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -36,3 +36,20 @@ async def test_failing_subscriber_does_not_block_and_logs_error(caplog, anyio_ba
         in record.getMessage()
         for record in caplog.records
     )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], scope="module")
+async def test_unsubscribed_handler_not_called(anyio_backend):
+    emitter = EventEmitter()
+    calls: list[int] = []
+
+    def handler(event):
+        calls.append(event.value)
+
+    emitter.subscribe(DummyEvent, handler)
+    emitter.unsubscribe(DummyEvent, handler)
+
+    await emitter.emit(DummyEvent(42))
+
+    assert calls == []


### PR DESCRIPTION
## Summary
- implement `EventEmitter.unsubscribe` to remove handlers safely
- test that unsubscribed handlers are not invoked

## Testing
- `black src/tino_storm/events.py tests/test_events.py`
- `ruff check src/tino_storm/events.py tests/test_events.py`
- `pytest tests/test_events.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f450b9aa88326b6a4a17c783f38d8