### PR TITLE
Batch summarize results in parallel

### DIFF
--- a/tests/test_default_provider_summary.py
+++ b/tests/test_default_provider_summary.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from tino_storm.providers import DefaultProvider
@@ -49,6 +50,36 @@ async def test_search_async_populates_summary_without_model(monkeypatch, anyio_b
     assert results[0].summary == "s"
 
 
+def test_search_sync_summarizes_in_parallel(monkeypatch):
+    monkeypatch.delenv("STORM_SUMMARY_MODEL", raising=False)
+    monkeypatch.setattr(
+        "tino_storm.providers.base.search_vaults",
+        lambda *a, **k: [
+            {"url": "u1", "snippets": ["s1"], "meta": {}},
+            {"url": "u2", "snippets": ["s2"], "meta": {}},
+            {"url": "u3", "snippets": ["s3"], "meta": {}},
+        ],
+    )
+
+    provider = DefaultProvider()
+    active = 0
+    max_active = 0
+
+    async def fake_summarize(snippets, *, max_chars=200):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0)
+        active -= 1
+        return snippets[0]
+
+    monkeypatch.setattr(provider, "_summarize_async", fake_summarize)
+    results = provider.search_sync("q", [])
+
+    assert [r.summary for r in results] == ["s1", "s2", "s3"]
+    assert max_active > 1
+
+
 @pytest.mark.anyio
 @pytest.mark.parametrize("anyio_backend", ["asyncio"], scope="module")
 async def test_search_async_uses_summarizer_when_model_set(monkeypatch, anyio_backend):
@@ -87,3 +118,35 @@ async def test_search_async_falls_back_on_summarizer_error(monkeypatch, anyio_ba
     results = await provider.search_async("q", [])
 
     assert results[0].summary == "s"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], scope="module")
+async def test_search_async_summarizes_in_parallel(monkeypatch, anyio_backend):
+    monkeypatch.delenv("STORM_SUMMARY_MODEL", raising=False)
+    monkeypatch.setattr(
+        "tino_storm.providers.base.search_vaults",
+        lambda *a, **k: [
+            {"url": "u1", "snippets": ["s1"], "meta": {}},
+            {"url": "u2", "snippets": ["s2"], "meta": {}},
+            {"url": "u3", "snippets": ["s3"], "meta": {}},
+        ],
+    )
+
+    provider = DefaultProvider()
+    active = 0
+    max_active = 0
+
+    async def fake_summarize(snippets, *, max_chars=200):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0)
+        active -= 1
+        return snippets[0]
+
+    monkeypatch.setattr(provider, "_summarize_async", fake_summarize)
+    results = await provider.search_async("q", [])
+
+    assert [r.summary for r in results] == ["s1", "s2", "s3"]
+    assert max_active > 1


### PR DESCRIPTION
## Summary
- run result summarization in parallel using asyncio.gather for sync and async searches
- test that summaries are generated concurrently without altering output

## Testing
- `black src/tino_storm/providers/base.py tests/test_default_provider_summary.py`
- `ruff check src/tino_storm/providers/base.py tests/test_default_provider_summary.py`
- `pytest tests/test_default_provider_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_689f48af77308326815c33af1f9b3691