### PR TITLE
Type ResearchAdded information_table as Dict

### DIFF
--- a/src/tino_storm/events.py
+++ b/src/tino_storm/events.py
@@ -6,7 +6,7 @@ import inspect
 import logging
 
 if TYPE_CHECKING:
-    from .storm_wiki.modules.storm_dataclass import StormInformationTable, StormArticle
+    from .storm_wiki.modules.storm_dataclass import StormArticle
 
 
 @dataclass
@@ -14,7 +14,7 @@ class ResearchAdded:
     """Event emitted when new research is ingested."""
 
     topic: str
-    information_table: "StormInformationTable"
+    information_table: Dict[str, Any]
 
 
 @dataclass

--- a/tests/test_search_errors.py
+++ b/tests/test_search_errors.py
@@ -8,9 +8,9 @@ from tino_storm.search import ResearchError, Provider, search, search_async
 
 def test_search_sync_error_emits_event(monkeypatch):
     monkeypatch.setattr(event_emitter, "_subscribers", {})
-    events = []
+    events: list[ResearchAdded] = []
 
-    async def handler(e):
+    async def handler(e: ResearchAdded) -> None:
         events.append(e)
 
     event_emitter.subscribe(ResearchAdded, handler)
@@ -29,9 +29,9 @@ def test_search_sync_error_emits_event(monkeypatch):
 
 def test_search_async_error_emits_event(monkeypatch):
     monkeypatch.setattr(event_emitter, "_subscribers", {})
-    events = []
+    events: list[ResearchAdded] = []
 
-    async def handler(e):
+    async def handler(e: ResearchAdded) -> None:
         events.append(e)
 
     event_emitter.subscribe(ResearchAdded, handler)


### PR DESCRIPTION
## Summary
- type `ResearchAdded.information_table` as `Dict[str, Any]`
- annotate event handlers in search error tests

## Testing
- `black src/tino_storm/events.py tests/test_search_errors.py`
- `ruff check src/tino_storm/events.py tests/test_search_errors.py`
- `pytest tests/test_search_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_689f48af37288326a121d42e33e4a882