### PR TITLE
Add multi-source provider combining docs and web

### DIFF
--- a/src/tino_storm/providers/__init__.py
+++ b/src/tino_storm/providers/__init__.py
@@ -3,6 +3,7 @@ from .parallel import ParallelProvider
 from .registry import ProviderRegistry, provider_registry, register_provider
 from .aggregator import ProviderAggregator
 from .docs_hub import DocsHubProvider
+from .multi_source import MultiSourceProvider
 
 
 __all__ = [
@@ -11,6 +12,7 @@ __all__ = [
     "ParallelProvider",
     "ProviderAggregator",
     "DocsHubProvider",
+    "MultiSourceProvider",
     "load_provider",
     "ProviderRegistry",
     "provider_registry",

--- a/src/tino_storm/providers/multi_source.py
+++ b/src/tino_storm/providers/multi_source.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable, List, Dict, Any, Optional
+
+from .base import DefaultProvider, format_bing_items
+from .docs_hub import DocsHubProvider
+from .registry import register_provider
+from ..ingest import search_vaults
+from ..retrieval import reciprocal_rank_fusion, score_results, add_posteriors
+from ..search_result import ResearchResult, as_research_result
+
+
+@register_provider("multi_source")
+class MultiSourceProvider(DefaultProvider):
+    """Provider that queries local vaults, DocsHub, and Bing in parallel."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.docs_provider = DocsHubProvider()
+
+    async def search_async(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[ResearchResult]:
+        vault_task = asyncio.to_thread(
+            search_vaults,
+            query,
+            vaults,
+            k_per_vault=k_per_vault,
+            rrf_k=rrf_k,
+            chroma_path=chroma_path,
+            vault=vault,
+        )
+        docs_task = self.docs_provider.search_async(
+            query,
+            vaults,
+            k_per_vault=k_per_vault,
+            rrf_k=rrf_k,
+            chroma_path=chroma_path,
+            vault=vault,
+        )
+        bing_task = asyncio.to_thread(self._bing_search, query)
+
+        vault_res, docs_res, bing_res = await asyncio.gather(
+            vault_task, docs_task, bing_task
+        )
+
+        rankings: List[List[Dict[str, Any]]] = []
+        if vault_res:
+            rankings.append(vault_res)
+        if docs_res:
+            rankings.append(
+                [
+                    {"url": r.url, "snippets": r.snippets, "meta": r.meta}
+                    for r in docs_res
+                ]
+            )
+        formatted = format_bing_items(bing_res)
+        if formatted:
+            rankings.append(score_results(formatted))
+        if not rankings:
+            return []
+
+        fused = reciprocal_rank_fusion(rankings, k=rrf_k)
+        scored = add_posteriors(fused)
+        return [as_research_result(r) for r in scored]
+
+    def search_sync(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+    ) -> List[ResearchResult]:
+        return asyncio.run(
+            self.search_async(
+                query,
+                vaults,
+                k_per_vault=k_per_vault,
+                rrf_k=rrf_k,
+                chroma_path=chroma_path,
+                vault=vault,
+            )
+        )

--- a/tests/test_multi_source_provider.py
+++ b/tests/test_multi_source_provider.py
@@ -1,0 +1,46 @@
+import asyncio
+
+from tino_storm.providers.multi_source import MultiSourceProvider
+from tino_storm.search_result import ResearchResult
+
+
+def test_multi_source_provider_queries_all_sources(monkeypatch):
+    gathered = {}
+    orig_gather = asyncio.gather
+
+    async def gather_wrapper(*tasks, **kwargs):
+        gathered["count"] = len(tasks)
+        return await orig_gather(*tasks, **kwargs)
+
+    async def fake_to_thread(func, *a, **k):
+        return func(*a, **k)
+
+    monkeypatch.setattr(asyncio, "gather", gather_wrapper)
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        "tino_storm.providers.multi_source.search_vaults",
+        lambda *a, **k: [{"url": "vault", "snippets": [], "meta": {}}],
+    )
+
+    provider = MultiSourceProvider()
+    monkeypatch.setattr(
+        provider,
+        "_bing_search",
+        lambda q: [{"url": "bing", "description": "desc", "title": "t"}],
+    )
+
+    async def docs_search_async(query, vaults, **kwargs):
+        return [ResearchResult(url="docs", snippets=[], meta={})]
+
+    monkeypatch.setattr(provider.docs_provider, "search_async", docs_search_async)
+
+    async def run():
+        return await provider.search_async("q", ["v"])
+
+    results = asyncio.run(run())
+
+    assert gathered["count"] == 3
+    assert {r.url for r in results} == {"vault", "docs", "bing"}
+    bing_result = next(r for r in results if r.url == "bing")
+    assert bing_result.snippets == ["desc"]
+    assert bing_result.meta["title"] == "t"


### PR DESCRIPTION
## Summary
- add MultiSourceProvider to query local vaults, DocsHub, and Bing concurrently
- expose MultiSourceProvider via providers package
- test MultiSourceProvider merges results from all sources

## Testing
- `black src/tino_storm/providers/multi_source.py src/tino_storm/providers/__init__.py tests/test_multi_source_provider.py`
- `ruff check src/tino_storm/providers/multi_source.py src/tino_storm/providers/__init__.py tests/test_multi_source_provider.py`
- `pytest tests/test_multi_source_provider.py`


------
https://chatgpt.com/codex/tasks/task_e_689f4f2d9ccc8326a5f3ab622050d89d