### PR TITLE
feat(events): add synchronous event emission

### DIFF
--- a/src/tino_storm/events.py
+++ b/src/tino_storm/events.py
@@ -1,7 +1,21 @@
+"""Event system for publishing domain events.
+
+Handlers can be subscribed to concrete event types and invoked when events are
+emitted. Use :meth:`EventEmitter.emit` within asynchronous code and
+:meth:`EventEmitter.emit_sync` from synchronous code. Both methods invoke each
+handler safely and log errors without interrupting other subscribers.
+
+Example:
+    >>> emitter = EventEmitter()
+    >>> emitter.subscribe(ResearchAdded, handle_research)
+    >>> emitter.emit_sync(ResearchAdded(topic="ai", information_table={}))
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Type, Any, TYPE_CHECKING, Optional
+import asyncio
 import inspect
 import logging
 
@@ -82,6 +96,44 @@ class EventEmitter:
                         handler_name,
                         type(event).__name__,
                     )
+
+    def emit_sync(
+        self,
+        event: Any,
+        on_error: Optional[
+            Callable[[Callable[[Any], Any], Any, Exception], None]
+        ] = None,
+    ) -> None:
+        """Synchronously emit an event to all subscribed handlers.
+
+        Handlers are invoked safely. If a handler returns a coroutine, it is
+        executed using a fresh asyncio event loop.
+
+        Args:
+            event: The event instance to emit.
+            on_error: Optional callback ``(handler, event, exception)`` used
+                for custom error logging.
+        """
+        loop: Optional[asyncio.AbstractEventLoop] = None
+        for handler in self._subscribers.get(type(event), []):
+            try:
+                result = handler(event)
+                if inspect.isawaitable(result):
+                    if loop is None:
+                        loop = asyncio.new_event_loop()
+                    loop.run_until_complete(result)
+            except Exception as exc:  # noqa: BLE001
+                if on_error is not None:
+                    on_error(handler, event, exc)
+                else:
+                    handler_name = getattr(handler, "__name__", repr(handler))
+                    logging.exception(
+                        "Error in handler %s for event %s",
+                        handler_name,
+                        type(event).__name__,
+                    )
+        if loop is not None:
+            loop.close()
 
 
 event_emitter = EventEmitter()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,4 +1,5 @@
 import logging
+import asyncio
 from dataclasses import dataclass
 
 import pytest
@@ -53,3 +54,46 @@ async def test_unsubscribed_handler_not_called(anyio_backend):
     await emitter.emit(DummyEvent(42))
 
     assert calls == []
+
+
+def test_emit_sync_runs_sync_and_async_handlers():
+    emitter = EventEmitter()
+    calls = []
+
+    def sync_handler(event):
+        calls.append(("sync", event.value))
+
+    async def async_handler(event):
+        await asyncio.sleep(0)
+        calls.append(("async", event.value))
+
+    emitter.subscribe(DummyEvent, sync_handler)
+    emitter.subscribe(DummyEvent, async_handler)
+
+    emitter.emit_sync(DummyEvent(1))
+
+    assert calls == [("sync", 1), ("async", 1)]
+
+
+def test_emit_sync_failing_handler_does_not_block_and_logs_error(caplog):
+    emitter = EventEmitter()
+    calls = []
+
+    def failing_handler(event):
+        raise RuntimeError("boom")
+
+    def good_handler(event):
+        calls.append(event.value)
+
+    emitter.subscribe(DummyEvent, failing_handler)
+    emitter.subscribe(DummyEvent, good_handler)
+
+    with caplog.at_level(logging.ERROR):
+        emitter.emit_sync(DummyEvent(5))
+
+    assert calls == [5]
+    assert any(
+        record.levelno == logging.ERROR
+        and "Error in handler failing_handler for event DummyEvent" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- add synchronous `emit_sync` helper that awaits async handlers using a new loop
- document synchronous emission in the events module docstring
- cover sync emission with tests

## Testing
- `ruff check src/tino_storm/events.py tests/test_events.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0af9515948326add4b96d82d28353