### PR TITLE
Use sync event emission in search error path

### DIFF
--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -111,10 +111,8 @@ def search(
                 )
         except Exception as e:
             logging.error(f"Search failed for query {query}: {e}")
-            asyncio.run(
-                event_emitter.emit(
-                    ResearchAdded(topic=query, information_table={"error": str(e)})
-                )
+            event_emitter.emit_sync(
+                ResearchAdded(topic=query, information_table={"error": str(e)})
             )
             raise ResearchError(str(e)) from e
 


### PR DESCRIPTION
## Summary
- replace asyncio.run(event_emitter.emit(...)) with event_emitter.emit_sync for search error handling

## Testing
- `black --check src/tino_storm/search.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0bda39e648326b186a49ea86a9877