### PR TITLE
Use synchronous event emission in search_sync

### DIFF
--- a/src/tino_storm/providers/aggregator.py
+++ b/src/tino_storm/providers/aggregator.py
@@ -104,11 +104,9 @@ class ProviderAggregator(Provider):
             except Exception as e:
                 logging.exception("Provider %s failed in search_sync", p)
                 provider_name = getattr(p, "name", p.__class__.__name__)
-                asyncio.run(
-                    event_emitter.emit(
-                        ResearchAdded(
-                            topic=provider_name, information_table={"error": str(e)}
-                        )
+                event_emitter.emit_sync(
+                    ResearchAdded(
+                        topic=provider_name, information_table={"error": str(e)}
                     )
                 )
                 continue


### PR DESCRIPTION
## Summary
- Replace `asyncio.run(event_emitter.emit(...))` with `event_emitter.emit_sync(...)` in the synchronous search path

## Testing
- `pre-commit run --files src/tino_storm/providers/aggregator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0bda2d0308326b9356fbe51da73f2