### PR TITLE
Test emit_sync multi-handler failure path

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -94,6 +94,43 @@ def test_emit_sync_failing_handler_does_not_block_and_logs_error(caplog):
     assert calls == [5]
     assert any(
         record.levelno == logging.ERROR
-        and "Error in handler failing_handler for event DummyEvent" in record.getMessage()
+        and "Error in handler failing_handler for event DummyEvent"
+        in record.getMessage()
         for record in caplog.records
     )
+
+
+def test_emit_sync_multiple_handlers_with_failures_logs_errors_and_continues(caplog):
+    emitter = EventEmitter()
+    calls = []
+
+    def failing_handler_one(event):
+        raise RuntimeError("boom1")
+
+    async def async_failing_handler(event):
+        await asyncio.sleep(0)
+        raise RuntimeError("boom2")
+
+    def good_handler_one(event):
+        calls.append(("good1", event.value))
+
+    async def good_handler_two(event):
+        await asyncio.sleep(0)
+        calls.append(("good2", event.value))
+
+    emitter.subscribe(DummyEvent, failing_handler_one)
+    emitter.subscribe(DummyEvent, good_handler_one)
+    emitter.subscribe(DummyEvent, async_failing_handler)
+    emitter.subscribe(DummyEvent, good_handler_two)
+
+    with caplog.at_level(logging.ERROR):
+        emitter.emit_sync(DummyEvent(7))
+
+    assert calls == [("good1", 7), ("good2", 7)]
+    error_messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.ERROR
+    ]
+    assert any("failing_handler_one" in msg for msg in error_messages)
+    assert any("async_failing_handler" in msg for msg in error_messages)


### PR DESCRIPTION
## Summary
- add regression test covering emit_sync with multiple handlers including failures

## Testing
- `black --check tests/test_events.py`
- `ruff check tests/test_events.py`
- `pytest tests/test_events.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0cafe53c08326aab74875fa057ade