### PR TITLE
Handle provider loading errors

### DIFF
--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -23,7 +23,10 @@ def _resolve_provider(provider: Provider | str | None) -> Provider:
     if provider is None:
         spec = os.environ.get("STORM_SEARCH_PROVIDER")
         if spec:
-            return load_provider(spec)
+            try:
+                return load_provider(spec)
+            except (ImportError, TypeError) as e:
+                raise ResearchError(f"Failed to load provider '{spec}': {e}") from e
         return DefaultProvider()
     if isinstance(provider, str):
         if "," in provider:
@@ -32,7 +35,10 @@ def _resolve_provider(provider: Provider | str | None) -> Provider:
         try:
             return provider_registry.get(provider)
         except KeyError:
-            return load_provider(provider)
+            try:
+                return load_provider(provider)
+            except (ImportError, TypeError) as e:
+                raise ResearchError(f"Failed to load provider '{provider}': {e}") from e
     return provider
 
 

--- a/tests/test_provider_loading.py
+++ b/tests/test_provider_loading.py
@@ -11,6 +11,7 @@ from tino_storm.providers import (
     ParallelProvider,
     DefaultProvider,
 )
+from tino_storm.search import ResearchError, _resolve_provider
 from tino_storm.search_result import ResearchResult
 
 
@@ -25,6 +26,21 @@ def test_load_provider_raises(monkeypatch):
 
     with pytest.raises(TypeError):
         load_provider("dummy_mod.NotProvider")
+
+
+def test_resolve_provider_invalid_string(monkeypatch):
+    mod = types.ModuleType("dummy_mod2")
+
+    class NotProvider:
+        pass
+
+    mod.NotProvider = NotProvider
+    monkeypatch.setitem(sys.modules, "dummy_mod2", mod)
+
+    with pytest.raises(ResearchError) as exc:
+        _resolve_provider("dummy_mod2.NotProvider")
+
+    assert "Failed to load provider 'dummy_mod2.NotProvider'" in str(exc.value)
 
 
 def test_search_uses_env_provider(monkeypatch):


### PR DESCRIPTION
## Summary
- raise `ResearchError` with helpful message when dynamic provider loading fails
- test `_resolve_provider` for informative error message on invalid provider strings

## Testing
- `SKIP=black pre-commit run --files src/tino_storm/search.py tests/test_provider_loading.py`
- `pytest tests/test_provider_loading.py::test_resolve_provider_invalid_string -q`


------
https://chatgpt.com/codex/tasks/task_e_68a49148effc8326b51f77a578407546