### PR TITLE
Register ParallelProvider in provider registry

### DIFF
--- a/src/tino_storm/providers/parallel.py
+++ b/src/tino_storm/providers/parallel.py
@@ -4,11 +4,13 @@ import asyncio
 from typing import Iterable, List, Dict, Any, Optional
 
 from .base import DefaultProvider, format_bing_items
+from .registry import register_provider
 from ..ingest import search_vaults
 from ..retrieval import reciprocal_rank_fusion, score_results, add_posteriors
 from ..search_result import ResearchResult, as_research_result
 
 
+@register_provider("parallel")
 class ParallelProvider(DefaultProvider):
     """Provider that queries local vaults and Bing concurrently."""
 


### PR DESCRIPTION
## Summary
- register `ParallelProvider` with the provider registry under `"parallel"`

## Testing
- `black src/tino_storm/providers/parallel.py`
- `ruff check src/tino_storm/providers/parallel.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7099e388483268cb79bcbcc2e5199