### PR TITLE
Handle failing sources in MultiSourceProvider

### DIFF
--- a/tests/test_multi_source_provider.py
+++ b/tests/test_multi_source_provider.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from tino_storm.events import ResearchAdded, event_emitter
 from tino_storm.providers.multi_source import MultiSourceProvider
 from tino_storm.search_result import ResearchResult
 
@@ -44,3 +45,44 @@ def test_multi_source_provider_queries_all_sources(monkeypatch):
     bing_result = next(r for r in results if r.url == "bing")
     assert bing_result.snippets == ["desc"]
     assert bing_result.meta["title"] == "t"
+
+
+def test_multi_source_provider_handles_source_failure(monkeypatch):
+    monkeypatch.setattr(event_emitter, "_subscribers", {})
+    events: list[ResearchAdded] = []
+
+    async def handler(e: ResearchAdded) -> None:
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
+
+    async def fake_to_thread(func, *a, **k):
+        return func(*a, **k)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        "tino_storm.providers.multi_source.search_vaults",
+        lambda *a, **k: [{"url": "vault", "snippets": [], "meta": {}}],
+    )
+
+    provider = MultiSourceProvider()
+
+    def raise_bing(_q: str):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(provider, "_bing_search", raise_bing)
+
+    async def docs_search_async(query, vaults, **kwargs):
+        return [ResearchResult(url="docs", snippets=[], meta={})]
+
+    monkeypatch.setattr(provider.docs_provider, "search_async", docs_search_async)
+
+    async def run():
+        return await provider.search_async("q", ["v"])
+
+    results = asyncio.run(run())
+
+    assert {r.url for r in results} == {"vault", "docs"}
+    assert len(events) == 1
+    assert events[0].topic == "q"
+    assert events[0].information_table["error"] == "boom"


### PR DESCRIPTION
## Summary
- guard MultiSourceProvider against individual source failures by emitting `ResearchAdded` events and continuing with remaining results
- add regression test for a failing source to ensure results still include healthy providers

## Testing
- `pre-commit run --files src/tino_storm/providers/multi_source.py tests/test_multi_source_provider.py`
- `pytest tests/test_multi_source_provider.py`


------
https://chatgpt.com/codex/tasks/task_e_68a72954686883268a2d0e5d968211de