### PR TITLE
Log provider entry-point loading errors

### DIFF
--- a/src/tino_storm/providers/registry.py
+++ b/src/tino_storm/providers/registry.py
@@ -22,7 +22,10 @@ class ProviderRegistry:
         for ep in entry_points(group="tino_storm.providers"):
             try:
                 provider = ep.load()
-            except Exception:
+            except Exception as exc:  # pragma: no cover - warning handled
+                logging.warning(
+                    "Failed to load provider entry-point %s: %s", ep.name, exc
+                )
                 continue
             self.register(ep.name, provider)
 

--- a/tests/test_provider_entrypoints.py
+++ b/tests/test_provider_entrypoints.py
@@ -1,11 +1,14 @@
 from types import SimpleNamespace
+import logging
 
 from tino_storm.providers import Provider
 from tino_storm.providers.registry import ProviderRegistry
 
 
 class DummyProvider(Provider):
-    async def search_async(self, query, vaults, **kwargs):  # pragma: no cover - simple stub
+    async def search_async(
+        self, query, vaults, **kwargs
+    ):  # pragma: no cover - simple stub
         return []
 
     def search_sync(self, query, vaults, **kwargs):  # pragma: no cover - simple stub
@@ -19,8 +22,26 @@ def test_loads_providers_from_entry_points(monkeypatch):
         assert group == "tino_storm.providers"
         return [dummy_ep]
 
-    monkeypatch.setattr(
-        "tino_storm.providers.registry.entry_points", fake_entry_points
-    )
+    monkeypatch.setattr("tino_storm.providers.registry.entry_points", fake_entry_points)
     registry = ProviderRegistry()
     assert isinstance(registry.get("dummy"), DummyProvider)
+
+
+def test_logs_warning_for_faulty_entry_point(monkeypatch, caplog):
+    def bad_load():
+        raise RuntimeError("boom")
+
+    bad_ep = SimpleNamespace(name="bad", load=bad_load)
+
+    def fake_entry_points(*, group):
+        assert group == "tino_storm.providers"
+        return [bad_ep]
+
+    monkeypatch.setattr("tino_storm.providers.registry.entry_points", fake_entry_points)
+
+    with caplog.at_level(logging.WARNING):
+        registry = ProviderRegistry()
+
+    assert "bad" in caplog.text
+    assert "boom" in caplog.text
+    assert "bad" not in registry.available()


### PR DESCRIPTION
## Summary
- log a warning when provider entry-point loading fails
- test that faulty entry-point logs a warning and is skipped

## Testing
- `black src/tino_storm/providers/registry.py tests/test_provider_entrypoints.py`
- `ruff check src/tino_storm/providers/registry.py tests/test_provider_entrypoints.py`
- `pytest tests/test_provider_entrypoints.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac871a86a083269223c06f619e9418