### PR TITLE
Clean up summary tasks after completion

### DIFF
--- a/src/tino_storm/providers/base.py
+++ b/src/tino_storm/providers/base.py
@@ -164,6 +164,7 @@ class DefaultProvider(Provider):
 
         task: asyncio.Task = asyncio.create_task(_run())
         self._summary_tasks[key] = task
+        task.add_done_callback(lambda t, k=key: self._summary_tasks.pop(k, None))
         return await task
 
     def _run(self, coro: Coroutine[Any, Any, Any]) -> Any:

--- a/tests/test_default_provider_summary.py
+++ b/tests/test_default_provider_summary.py
@@ -221,3 +221,14 @@ async def test_search_async_caches_duplicate_snippets(monkeypatch, anyio_backend
 
     assert [r.summary for r in results] == ["summary", "summary"]
     assert calls == 1
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], scope="module")
+async def test_summarize_async_clears_completed_tasks(monkeypatch, anyio_backend):
+    monkeypatch.delenv("STORM_SUMMARY_MODEL", raising=False)
+    provider = DefaultProvider()
+
+    for i in range(3):
+        await provider._summarize_async([f"s{i}"])
+        assert provider._summary_tasks == {}


### PR DESCRIPTION
## Summary
- remove completed summary tasks from cache in `DefaultProvider._summarize_async`
- add regression test ensuring `_summary_tasks` doesn't grow on repeated summarizations

## Testing
- `black src/tino_storm/providers/base.py tests/test_default_provider_summary.py`
- `ruff check src/tino_storm/providers/base.py tests/test_default_provider_summary.py`
- `pytest tests/test_default_provider_summary.py::test_summarize_async_clears_completed_tasks -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac8719b6b88326938ad8b12d685a2e