### PR TITLE
Use persistent event loop for provider summarization

### DIFF
--- a/tests/test_default_provider_loop.py
+++ b/tests/test_default_provider_loop.py
@@ -1,0 +1,26 @@
+from tino_storm.providers.base import (
+    DefaultProvider,
+    _get_loop,
+    _get_loop_thread,
+    _stop_loop,
+)
+
+
+def test_summarize_reuses_loop_and_shutdown(monkeypatch):
+    monkeypatch.delenv("STORM_SUMMARY_MODEL", raising=False)
+    provider = DefaultProvider()
+
+    provider._summarize(["a"])
+    loop1 = _get_loop()
+    thread1 = _get_loop_thread()
+    assert loop1 is not None
+    assert thread1 is not None and thread1.is_alive()
+
+    provider._summarize(["b"])
+    loop2 = _get_loop()
+    assert loop1 is loop2
+
+    _stop_loop()
+    assert _get_loop() is None
+    thread2 = _get_loop_thread()
+    assert thread2 is None or not thread2.is_alive()


### PR DESCRIPTION
## Summary
- run DefaultProvider coroutines on a background event loop with thread and atexit cleanup
- expose loop helpers and rewrite `_run` to use `run_coroutine_threadsafe`
- add unit test ensuring `_summarize` reuses the loop and shuts down cleanly

## Testing
- `ruff check src/tino_storm/providers/base.py tests/test_default_provider_loop.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e46daefc8326bd41fe87f6cbaa49