### PR TITLE
Add timeout handling for vault searches

### DIFF
--- a/src/tino_storm/providers/base.py
+++ b/src/tino_storm/providers/base.py
@@ -207,6 +207,7 @@ class DefaultProvider(Provider):
             rrf_k=rrf_k,
             chroma_path=chroma_path,
             vault=vault,
+            timeout=timeout,
         )
         if raw_results:
             results = [as_research_result(r) for r in raw_results]
@@ -248,6 +249,7 @@ class DefaultProvider(Provider):
             rrf_k=rrf_k,
             chroma_path=chroma_path,
             vault=vault,
+            timeout=timeout,
         )
         if raw_results:
             results = [as_research_result(r) for r in raw_results]

--- a/src/tino_storm/providers/docs_hub.py
+++ b/src/tino_storm/providers/docs_hub.py
@@ -36,6 +36,7 @@ class DocsHubProvider(Provider):
                 rrf_k=rrf_k,
                 chroma_path=chroma_path,
                 vault=vault,
+                timeout=timeout,
             )
             return [as_research_result(r) for r in raw_results]
         except Exception as e:  # pragma: no cover - network/IO errors
@@ -65,6 +66,7 @@ class DocsHubProvider(Provider):
                 rrf_k=rrf_k,
                 chroma_path=chroma_path,
                 vault=vault,
+                timeout=timeout,
             )
             return [as_research_result(r) for r in raw_results]
         except Exception as e:  # pragma: no cover - network/IO errors

--- a/src/tino_storm/providers/multi_source.py
+++ b/src/tino_storm/providers/multi_source.py
@@ -40,6 +40,7 @@ class MultiSourceProvider(DefaultProvider):
             rrf_k=rrf_k,
             chroma_path=chroma_path,
             vault=vault,
+            timeout=timeout,
         )
         docs_task = self.docs_provider.search_async(
             query,

--- a/src/tino_storm/providers/parallel.py
+++ b/src/tino_storm/providers/parallel.py
@@ -33,6 +33,7 @@ class ParallelProvider(DefaultProvider):
             rrf_k=rrf_k,
             chroma_path=chroma_path,
             vault=vault,
+            timeout=timeout,
         )
         bing_task = asyncio.to_thread(self._bing_search, query)
         vault_res, bing_res = await asyncio.gather(vault_task, bing_task)

--- a/tests/test_search_vaults_timeout.py
+++ b/tests/test_search_vaults_timeout.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import time
+import pytest
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from tino_storm.search import search, ResearchError  # noqa: E402
+
+
+class SlowCollection:
+    def query(self, *args, **kwargs):
+        time.sleep(0.2)
+        return {"documents": [[]], "metadatas": [[]]}
+
+
+class DummyClient:
+    def __init__(self, collection):
+        self.collection = collection
+
+    def get_or_create_collection(self, name):
+        return self.collection
+
+
+def test_search_vaults_timeout(monkeypatch):
+    coll = SlowCollection()
+    client = DummyClient(coll)
+    monkeypatch.setattr("chromadb.PersistentClient", lambda *a, **k: client)
+    monkeypatch.setattr(
+        "tino_storm.ingest.search.get_passphrase", lambda vault=None: None
+    )
+
+    with pytest.raises(ResearchError):
+        search("q", ["v1"], timeout=0.05)


### PR DESCRIPTION
## Summary
- allow `search_vaults` to enforce optional timeouts using `asyncio.to_thread` and `asyncio.wait_for`
- propagate the `timeout` parameter through built-in providers
- add regression test ensuring slow collections trigger `ResearchError`

## Testing
- `black src/tino_storm/ingest/search.py src/tino_storm/providers/base.py src/tino_storm/providers/docs_hub.py src/tino_storm/providers/parallel.py src/tino_storm/providers/multi_source.py tests/test_search_vaults_timeout.py --check`
- `ruff check src/tino_storm/ingest/search.py src/tino_storm/providers/base.py src/tino_storm/providers/docs_hub.py src/tino_storm/providers/parallel.py src/tino_storm/providers/multi_source.py tests/test_search_vaults_timeout.py`
- `pytest tests/test_search_vaults_timeout.py tests/test_search_vaults.py tests/test_search_function.py tests/test_docs_hub_provider.py tests/test_multi_source_provider.py tests/test_default_provider_summary.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e46cff108326bebeb7b5b02a47b7