### PR TITLE
Add summarizer timeout configuration

### DIFF
--- a/docs/research_plugin.md
+++ b/docs/research_plugin.md
@@ -28,7 +28,9 @@ The search API returns a list of `ResearchResult` objects containing the URL,
 text snippets, optional metadata and a short summary from the retrieved
 documents. By default the first snippet is used as the summary. If the
 `STORM_SUMMARY_MODEL` environment variable is set, that model will be invoked
-to generate a one-sentence summary for each result.
+to generate a one-sentence summary for each result. The optional
+`STORM_SUMMARY_TIMEOUT` variable limits how long the summarizer is allowed to
+run before the first snippet is used as a fallback.
 
 ```python
 from tino_storm.search_result import ResearchResult


### PR DESCRIPTION
## Summary
- limit summarizer runs with configurable timeout
- document STORM_SUMMARY_TIMEOUT environment variable
- test summarizer timeout behavior

## Testing
- `black src/tino_storm/providers/base.py tests/test_default_provider_summary.py`
- `ruff check src/tino_storm/providers/base.py tests/test_default_provider_summary.py`
- `pytest tests/test_default_provider_summary.py::test_search_async_summarizer_timeout -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f64f2eb08326bbe0aca54ff5ed0a