### PR TITLE
Graceful fallback to default provider on invalid search spec

### DIFF
--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -41,9 +41,7 @@ def _resolve_provider(provider: Provider | str | None) -> Provider:
             except Exception as e:
                 logging.exception("Failed to load provider '%s'", spec)
                 _emit_load_error(spec, e)
-                raise ResearchError(
-                    f"Failed to load provider '{spec}': {e}", provider_spec=spec
-                ) from e
+                return DefaultProvider()
         return DefaultProvider()
     if isinstance(provider, str):
         if "," in provider:
@@ -57,10 +55,7 @@ def _resolve_provider(provider: Provider | str | None) -> Provider:
             except Exception as e:
                 logging.exception("Failed to load provider '%s'", provider)
                 _emit_load_error(provider, e)
-                raise ResearchError(
-                    f"Failed to load provider '{provider}': {e}",
-                    provider_spec=provider,
-                ) from e
+                return DefaultProvider()
     return provider
 
 


### PR DESCRIPTION
## Summary
- default to `DefaultProvider` when specified search provider cannot be loaded
- record provider load failures with a `ResearchAdded` event
- add regression tests for invalid provider specs and env vars

## Testing
- `pre-commit run --files src/tino_storm/search.py tests/test_search_errors.py tests/test_provider_loading.py`
- `pytest tests/test_search_errors.py tests/test_provider_loading.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f64f0c1c8326998cd6591e2b2fb4