### PR TITLE
Add vector DB provider

### DIFF
--- a/docs/vector_db_provider.md
+++ b/docs/vector_db_provider.md
@@ -1,0 +1,28 @@
+# VectorDBProvider
+
+The `VectorDBProvider` allows Tino Storm to query external vector databases
+using an existing retrieval helper such as `VectorRM`.
+
+## Usage
+
+```python
+from tino_storm.providers import VectorDBProvider
+from tino_storm.rm import VectorRM
+
+# Configure the retrieval model (e.g., connect to Qdrant)
+rm = VectorRM(collection_name="docs", embedding_model="BAAI/bge-m3")
+rm.init_offline_vector_db(vector_store_path="/path/to/store")
+
+provider = VectorDBProvider(rm)
+results = provider.search_sync("example query", vaults=[])
+```
+
+The provider expects the retriever to expose a `forward` method returning
+results in the standard search format:
+
+```python
+[{"url": "https://example.com", "snippets": ["..."], "meta": {...}}]
+```
+
+Errors during retrieval are reported via the `ResearchAdded` event with the
+error message included in the information table.

--- a/src/tino_storm/providers/__init__.py
+++ b/src/tino_storm/providers/__init__.py
@@ -4,6 +4,7 @@ from .registry import ProviderRegistry, provider_registry, register_provider
 from .aggregator import ProviderAggregator
 from .docs_hub import DocsHubProvider
 from .multi_source import MultiSourceProvider
+from .vector_db import VectorDBProvider
 
 
 __all__ = [
@@ -13,6 +14,7 @@ __all__ = [
     "ProviderAggregator",
     "DocsHubProvider",
     "MultiSourceProvider",
+    "VectorDBProvider",
     "load_provider",
     "ProviderRegistry",
     "provider_registry",

--- a/src/tino_storm/providers/vector_db.py
+++ b/src/tino_storm/providers/vector_db.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Iterable, List, Optional, Any
+
+from .base import Provider
+from .registry import register_provider
+from ..events import ResearchAdded, event_emitter
+from ..search_result import ResearchResult, as_research_result
+
+
+@register_provider("vector_db")
+class VectorDBProvider(Provider):
+    """Provider that queries a vector database using a retrieval helper.
+
+    The provider expects a *retriever* object implementing a ``forward``
+    method that accepts a query string and returns an iterable of mappings
+    containing ``url`` and ``snippets`` keys (e.g. :class:`~tino_storm.rm.VectorRM`).
+    When instantiated without a retriever, the provider will return empty
+    results and emit an error event when ``search`` is called.
+    """
+
+    def __init__(self, retriever: Any | None = None):
+        self.retriever = retriever
+
+    def _ensure_retriever(self) -> Any:
+        if self.retriever is None:
+            raise RuntimeError("VectorDBProvider requires a retriever instance")
+        return self.retriever
+
+    async def search_async(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> List[ResearchResult]:
+        """Asynchronously query the vector store without blocking."""
+
+        try:
+            retriever = self._ensure_retriever()
+            raw_results = await asyncio.to_thread(retriever.forward, query)
+            return [as_research_result(r) for r in raw_results]
+        except Exception as e:  # pragma: no cover - network/IO errors
+            logging.exception("VectorDBProvider search_async failed")
+            await event_emitter.emit(
+                ResearchAdded(topic=query, information_table={"error": str(e)})
+            )
+            return []
+
+    def search_sync(
+        self,
+        query: str,
+        vaults: Iterable[str],
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> List[ResearchResult]:
+        """Synchronously query the vector store."""
+
+        try:
+            retriever = self._ensure_retriever()
+            raw_results = retriever.forward(query)
+            return [as_research_result(r) for r in raw_results]
+        except Exception as e:  # pragma: no cover - network/IO errors
+            logging.exception("VectorDBProvider search_sync failed")
+            event_emitter.emit_sync(
+                ResearchAdded(topic=query, information_table={"error": str(e)})
+            )
+            return []

--- a/tests/test_vector_db_provider.py
+++ b/tests/test_vector_db_provider.py
@@ -1,0 +1,53 @@
+import asyncio
+
+from tino_storm.providers.vector_db import VectorDBProvider
+from tino_storm.events import ResearchAdded
+
+
+class DummyRetriever:
+    def __init__(self):
+        self.calls = []
+
+    def forward(self, query):
+        self.calls.append(query)
+        return [{"url": "u", "snippets": ["s"], "meta": {"title": "t"}}]
+
+
+def test_basic_search_sync_and_async():
+    retriever = DummyRetriever()
+    provider = VectorDBProvider(retriever)
+
+    sync_res = provider.search_sync("q", [])
+    assert len(sync_res) == 1
+    assert sync_res[0].url == "u"
+
+    async_res = asyncio.run(provider.search_async("q", []))
+    assert len(async_res) == 1
+    assert async_res[0].url == "u"
+
+    assert retriever.calls == ["q", "q"]
+
+
+def test_error_handling(monkeypatch):
+    class BoomRetriever:
+        def forward(self, query):
+            raise RuntimeError("boom")
+
+    events = []
+
+    def record(event):
+        events.append(event)
+
+    monkeypatch.setattr(
+        "tino_storm.providers.vector_db.event_emitter.emit_sync",
+        record,
+    )
+
+    provider = VectorDBProvider(BoomRetriever())
+    res = provider.search_sync("bad", [])
+    assert res == []
+
+    assert len(events) == 1
+    assert isinstance(events[0], ResearchAdded)
+    assert events[0].topic == "bad"
+    assert "boom" in events[0].information_table["error"]


### PR DESCRIPTION
## Summary
- add VectorDBProvider to query external vector databases via retrieval helpers
- expose provider in package API and document usage
- test VectorDBProvider for successful queries and error handling

## Testing
- `pre-commit run --files src/tino_storm/providers/vector_db.py src/tino_storm/providers/__init__.py docs/vector_db_provider.md tests/test_vector_db_provider.py`
- `pytest tests/test_vector_db_provider.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8429a90b483269dccb613afd63c35