### PR TITLE
Refactor aggregator sync search to avoid asyncio.run

### DIFF
--- a/tests/test_provider_aggregator.py
+++ b/tests/test_provider_aggregator.py
@@ -246,3 +246,14 @@ def test_timeout_emits_event_and_skips_provider(monkeypatch):
     assert len(events) == 1
     assert events[0].topic == "slow"
     assert events[0].information_table["error"] == "timeout"
+
+
+def test_search_sync_inside_running_event_loop():
+    provider = ProviderAggregator([DummyProvider("p")])
+
+    async def run():
+        # Invoking search_sync while an event loop is already running should work
+        return provider.search_sync("q", [])
+
+    results = asyncio.run(run())
+    assert {r.url for r in results} == {"p"}


### PR DESCRIPTION
## Summary
- replace asyncio.run in ProviderAggregator.search_sync with ThreadPoolExecutor
- add regression test to call search_sync from inside a running event loop

## Testing
- `ruff check src/tino_storm/providers/aggregator.py tests/test_provider_aggregator.py`
- `pytest tests/test_provider_aggregator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b84299da048326b720eca2ddf2ae62