### PR TITLE
Return status from unsubscribe

### DIFF
--- a/src/tino_storm/events.py
+++ b/src/tino_storm/events.py
@@ -46,21 +46,25 @@ class EventEmitter:
     def subscribe(self, event_type: Type[Any], handler: Callable[[Any], Any]) -> None:
         self._subscribers.setdefault(event_type, []).append(handler)
 
-    def unsubscribe(self, event_type: Type[Any], handler: Callable[[Any], Any]) -> None:
+    def unsubscribe(self, event_type: Type[Any], handler: Callable[[Any], Any]) -> bool:
         """Remove a previously registered handler.
 
         The handler is removed from the subscriber list for ``event_type``.
-        If the handler or event type is not registered, the call is a no-op.
+        If the handler or event type is not registered, ``False`` is returned.
+
+        Returns:
+            ``True`` if the handler was removed, ``False`` otherwise.
         """
         handlers = self._subscribers.get(event_type)
         if not handlers:
-            return
+            return False
         try:
             handlers.remove(handler)
         except ValueError:
-            return
+            return False
         if not handlers:
             del self._subscribers[event_type]
+        return True
 
     async def emit(
         self,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -49,7 +49,8 @@ async def test_unsubscribed_handler_not_called(anyio_backend):
         calls.append(event.value)
 
     emitter.subscribe(DummyEvent, handler)
-    emitter.unsubscribe(DummyEvent, handler)
+    assert emitter.unsubscribe(DummyEvent, handler) is True
+    assert emitter.unsubscribe(DummyEvent, handler) is False
 
     await emitter.emit(DummyEvent(42))
 
@@ -70,7 +71,8 @@ async def test_unsubscribe_one_of_multiple_handlers(anyio_backend):
 
     emitter.subscribe(DummyEvent, handler_one)
     emitter.subscribe(DummyEvent, handler_two)
-    emitter.unsubscribe(DummyEvent, handler_one)
+    assert emitter.unsubscribe(DummyEvent, handler_one) is True
+    assert emitter.unsubscribe(DummyEvent, handler_one) is False
 
     await emitter.emit(DummyEvent(10))
 
@@ -103,7 +105,8 @@ async def test_unsubscribe_failing_handler_stops_errors(caplog, anyio_backend):
         for record in caplog.records
     )
 
-    emitter.unsubscribe(DummyEvent, failing_handler)
+    assert emitter.unsubscribe(DummyEvent, failing_handler) is True
+    assert emitter.unsubscribe(DummyEvent, failing_handler) is False
     caplog.clear()
     await emitter.emit(DummyEvent(2))
 


### PR DESCRIPTION
## Summary
- Allow EventEmitter.unsubscribe to indicate if removal succeeded
- Test unsubscribe return values and repeated calls

## Testing
- `ruff check src/tino_storm/events.py tests/test_events.py`
- `pytest tests/test_events.py`


------
https://chatgpt.com/codex/tasks/task_e_68b851a9f3d88326b9188729ae3642bd