### PR TITLE
Raise ResearchError when provider loading fails

### DIFF
--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -46,7 +46,7 @@ def _resolve_provider(provider: Provider | str | None) -> Provider:
             except Exception as e:
                 logging.exception("Failed to load provider '%s'", spec)
                 _emit_load_error(spec, e)
-                return DefaultProvider()
+                raise ResearchError(str(e), provider_spec=spec) from e
         return DefaultProvider()
     if isinstance(provider, str):
         if "," in provider:
@@ -62,7 +62,7 @@ def _resolve_provider(provider: Provider | str | None) -> Provider:
             except Exception as e:
                 logging.exception("Failed to load provider '%s'", provider)
                 _emit_load_error(provider, e)
-                return DefaultProvider()
+                raise ResearchError(str(e), provider_spec=provider) from e
     return provider
 
 


### PR DESCRIPTION
## Summary
- raise `ResearchError` when dynamic provider loading fails and emit an error event
- update tests to expect `ResearchError` instead of falling back to `DefaultProvider`

## Testing
- `ruff check src/tino_storm/search.py tests/test_provider_loading.py tests/test_search_errors.py`
- `black src/tino_storm/search.py tests/test_provider_loading.py tests/test_search_errors.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b860afb4a48326ae7ede5fa0440106