### PR TITLE
test: handle invalid search provider

### DIFF
--- a/tests/test_search_provider_failure.py
+++ b/tests/test_search_provider_failure.py
@@ -1,0 +1,29 @@
+import pytest
+
+import tino_storm
+from tino_storm.events import ResearchAdded, event_emitter
+from tino_storm.search import ResearchError, search as search_func
+
+
+def test_invalid_env_provider_emits_event(monkeypatch):
+    monkeypatch.setattr(event_emitter, "_subscribers", {})
+    events = []
+
+    def handler(e: ResearchAdded) -> None:
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
+
+    spec = "nonexistent.module.Provider"
+    monkeypatch.setenv("STORM_SEARCH_PROVIDER", spec)
+
+    monkeypatch.setattr(tino_storm, "search", search_func)
+
+    with pytest.raises(ResearchError) as exc:
+        tino_storm.search("topic", [])
+
+    assert exc.value.provider_spec == spec
+    assert len(events) == 1
+    event = events[0]
+    assert event.topic == spec
+    assert event.information_table["error"] == str(exc.value)


### PR DESCRIPTION
## Summary
- test search fails and emits ResearchAdded when STORM_SEARCH_PROVIDER points to invalid module

## Testing
- `black --check tests/test_search_provider_failure.py`
- `SKIP=black pre-commit run --files tests/test_search_provider_failure.py`
- `pytest tests/test_search_provider_failure.py`


------
https://chatgpt.com/codex/tasks/task_e_68bef77a72488326936c80809d835e0f