### PR TITLE
Document ResearchError for misconfigured providers

### DIFF
--- a/docs/research_plugin.md
+++ b/docs/research_plugin.md
@@ -51,6 +51,24 @@ export STORM_SEARCH_PROVIDER=my_package.providers.MyProvider
 This provider will be loaded automatically whenever `tino_storm.search()` is
 invoked.
 
+### Misconfigured providers
+
+If a provider specified via `STORM_SEARCH_PROVIDER` fails to load or lacks
+required settings, `tino_storm.search()` raises `ResearchError`. Wrap calls in a
+`try`/`except` block to handle these errors gracefully.
+
+```python
+import os
+import tino_storm
+from tino_storm.search import ResearchError
+
+os.environ["STORM_SEARCH_PROVIDER"] = "my_package.providers.MisconfiguredProvider"
+try:
+    tino_storm.search("large language models")
+except ResearchError as exc:
+    print("Provider misconfigured:", exc)
+```
+
 ### Registering providers programmatically
 
 Providers can also be registered directly in code using the provider


### PR DESCRIPTION
## Summary
- explain how misconfigured search providers raise `ResearchError`
- show try/except example using `tino_storm.search` with `STORM_SEARCH_PROVIDER`

## Testing
- no tests or linters run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68bef779965083269e096b98c048b249