### PR TITLE
Forward vault parameter to vector retriever

### DIFF
--- a/src/tino_storm/core/rm.py
+++ b/src/tino_storm/core/rm.py
@@ -204,7 +204,9 @@ class BingSearch(dspy.Retrieve):
             logging.error(f"Error occurs when fetching webpages for {queries}: {e}")
             asyncio.run(
                 event_emitter.emit(
-                    ResearchAdded(topic=str(queries), information_table={"error": str(e)})
+                    ResearchAdded(
+                        topic=str(queries), information_table={"error": str(e)}
+                    )
                 )
             )
             valid_url_to_snippets = {}

--- a/src/tino_storm/providers/aggregator.py
+++ b/src/tino_storm/providers/aggregator.py
@@ -143,9 +143,7 @@ class ProviderAggregator(Provider):
                 try:
                     r = future.result(timeout=actual_timeout)
                 except FuturesTimeoutError:
-                    logging.exception(
-                        "Provider %s timed out in search_sync", provider
-                    )
+                    logging.exception("Provider %s timed out in search_sync", provider)
                     provider_name = getattr(
                         provider, "name", provider.__class__.__name__
                     )
@@ -156,9 +154,7 @@ class ProviderAggregator(Provider):
                         )
                     )
                 except Exception as e:  # pragma: no cover - defensive
-                    logging.exception(
-                        "Provider %s failed in search_sync", provider
-                    )
+                    logging.exception("Provider %s failed in search_sync", provider)
                     provider_name = getattr(
                         provider, "name", provider.__class__.__name__
                     )

--- a/src/tino_storm/providers/vector_db.py
+++ b/src/tino_storm/providers/vector_db.py
@@ -44,7 +44,7 @@ class VectorDBProvider(Provider):
 
         try:
             retriever = self._ensure_retriever()
-            raw_results = await asyncio.to_thread(retriever.forward, query)
+            raw_results = await asyncio.to_thread(retriever.forward, query, vault=vault)
             return [as_research_result(r) for r in raw_results]
         except Exception as e:  # pragma: no cover - network/IO errors
             logging.exception("VectorDBProvider search_async failed")
@@ -68,7 +68,7 @@ class VectorDBProvider(Provider):
 
         try:
             retriever = self._ensure_retriever()
-            raw_results = retriever.forward(query)
+            raw_results = retriever.forward(query, vault=vault)
             return [as_research_result(r) for r in raw_results]
         except Exception as e:  # pragma: no cover - network/IO errors
             logging.exception("VectorDBProvider search_sync failed")

--- a/tests/test_vector_db_provider.py
+++ b/tests/test_vector_db_provider.py
@@ -8,8 +8,8 @@ class DummyRetriever:
     def __init__(self):
         self.calls = []
 
-    def forward(self, query):
-        self.calls.append(query)
+    def forward(self, query, vault=None):
+        self.calls.append((query, vault))
         return [{"url": "u", "snippets": ["s"], "meta": {"title": "t"}}]
 
 
@@ -17,20 +17,20 @@ def test_basic_search_sync_and_async():
     retriever = DummyRetriever()
     provider = VectorDBProvider(retriever)
 
-    sync_res = provider.search_sync("q", [])
+    sync_res = provider.search_sync("q", [], vault="vault1")
     assert len(sync_res) == 1
     assert sync_res[0].url == "u"
 
-    async_res = asyncio.run(provider.search_async("q", []))
+    async_res = asyncio.run(provider.search_async("q", [], vault="vault2"))
     assert len(async_res) == 1
     assert async_res[0].url == "u"
 
-    assert retriever.calls == ["q", "q"]
+    assert retriever.calls == [("q", "vault1"), ("q", "vault2")]
 
 
 def test_error_handling(monkeypatch):
     class BoomRetriever:
-        def forward(self, query):
+        def forward(self, query, vault=None):
             raise RuntimeError("boom")
 
     events = []
@@ -44,7 +44,7 @@ def test_error_handling(monkeypatch):
     )
 
     provider = VectorDBProvider(BoomRetriever())
-    res = provider.search_sync("bad", [])
+    res = provider.search_sync("bad", [], vault="vault1")
     assert res == []
 
     assert len(events) == 1


### PR DESCRIPTION
## Summary
- forward the optional `vault` argument through `search_async` and `search_sync`
- test that vector DB provider forwards the vault to the retriever
- apply formatter updates from pre-commit

## Testing
- `pre-commit run --files src/tino_storm/providers/vector_db.py tests/test_vector_db_provider.py`
- `pre-commit run --files src/tino_storm/core/rm.py src/tino_storm/providers/aggregator.py`
- `pytest tests/test_vector_db_provider.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c03d6b4af083269684621c278a2863