### PR TITLE
Refactor search helpers and adjust sync callers

### DIFF
--- a/src/tino_storm/__init__.py
+++ b/src/tino_storm/__init__.py
@@ -9,7 +9,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .search import search
+    from .search import search, search_sync
 
 __all__ = [
     "__version__",
@@ -22,6 +22,7 @@ __all__ = [
     "ResearchSkill",
     "search",
     "search_async",
+    "search_sync",
 ]
 
 __version__ = "1.2.0"
@@ -42,6 +43,7 @@ _ATTR_MAP = {
     "ResearchSkill": ("tino_storm.skills", "ResearchSkill"),
     "search": ("tino_storm.search", "search"),
     "search_async": ("tino_storm.search", "search_async"),
+    "search_sync": ("tino_storm.search", "search_sync"),
 }
 
 
@@ -56,12 +58,16 @@ def __getattr__(name: str):
 
 
 def __call__(query: str, **kwargs):
-    return search(query, **kwargs)
+    from .search import search_sync as _search_sync
+
+    return _search_sync(query, **kwargs)
 
 
 class _CallableModule(ModuleType):
     def __call__(self, query: str, **kwargs):
-        return search(query, **kwargs)
+        from .search import search_sync as _search_sync
+
+        return _search_sync(query, **kwargs)
 
 
 sys.modules[__name__].__class__ = _CallableModule

--- a/src/tino_storm/api.py
+++ b/src/tino_storm/api.py
@@ -1,6 +1,5 @@
 from typing import Optional, List
 import asyncio
-import inspect
 import logging
 import os
 from dataclasses import asdict
@@ -187,12 +186,10 @@ async def ingest(req: IngestRequest):
 
 @app.post("/search")
 async def search_endpoint(req: SearchRequest):
-    result = search(
+    result = await search(
         req.query,
         req.vaults,
         k_per_vault=req.k_per_vault,
         rrf_k=req.rrf_k,
     )
-    if inspect.isawaitable(result):
-        result = await result
     return {"results": [asdict(r) for r in result]}

--- a/src/tino_storm/cli.py
+++ b/src/tino_storm/cli.py
@@ -1,6 +1,6 @@
 import argparse
 
-from . import search
+from . import search_sync
 
 start_watcher = None  # populated lazily for ingest command
 
@@ -124,7 +124,7 @@ def main(argv=None):
             reddit_client_secret=args.reddit_client_secret,
         )
     elif args.command == "search":
-        results = search(
+        results = search_sync(
             args.query,
             args.vaults.split(","),
             k_per_vault=args.k_per_vault,

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -185,7 +185,7 @@ def test_ingest_endpoint(monkeypatch):
 def test_search_endpoint(monkeypatch):
     called = {}
 
-    def fake_search(query, vaults, *, k_per_vault=5, rrf_k=60):
+    async def fake_search(query, vaults, *, k_per_vault=5, rrf_k=60):
         called["args"] = (query, list(vaults), k_per_vault, rrf_k)
         return [ResearchResult(url="u", snippets=["s"], meta={})]
 
@@ -271,7 +271,7 @@ def test_search_endpoint_asyncio(monkeypatch):
 
     called = {}
 
-    def fake_search(query, vaults, *, k_per_vault=5, rrf_k=60):
+    async def fake_search(query, vaults, *, k_per_vault=5, rrf_k=60):
         called["args"] = (query, list(vaults), k_per_vault, rrf_k)
         return [ResearchResult(url="u", snippets=["s"], meta={})]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,7 +125,7 @@ def test_cli_search(monkeypatch, capsys):
         calls.append((query, list(vaults), k_per_vault, rrf_k))
         return [ResearchResult(url="example.com", snippets=["result"], meta={})]
 
-    monkeypatch.setattr("tino_storm.cli.search", fake_search)
+    monkeypatch.setattr("tino_storm.cli.search_sync", fake_search)
 
     main(["search", "--query", "ai", "--vaults", "science,notes"])
 
@@ -202,7 +202,7 @@ def test_cli_search_asyncio(monkeypatch, capsys):
         calls.append((query, list(vaults), k_per_vault, rrf_k))
         return [ResearchResult(url="example.com", snippets=["result"], meta={})]
 
-    monkeypatch.setattr("tino_storm.cli.search", fake_search)
+    monkeypatch.setattr("tino_storm.cli.search_sync", fake_search)
 
     async def _run():
         await asyncio.to_thread(

--- a/tests/test_module_callable.py
+++ b/tests/test_module_callable.py
@@ -1,3 +1,5 @@
+import importlib
+
 import tino_storm
 
 
@@ -9,7 +11,8 @@ def test_module_callable(monkeypatch):
         calls["kwargs"] = kwargs
         return "result"
 
-    monkeypatch.setitem(tino_storm.__dict__, "search", fake_search)
+    search_mod = importlib.import_module("tino_storm.search")
+    monkeypatch.setattr(search_mod, "search_sync", fake_search)
 
     result = tino_storm("my query", foo="bar")
 

--- a/tests/test_provider_aggregator.py
+++ b/tests/test_provider_aggregator.py
@@ -5,7 +5,7 @@ from typing import List
 from tino_storm.providers.base import Provider
 from tino_storm.providers.registry import provider_registry
 from tino_storm.providers.aggregator import ProviderAggregator, canonical_url
-from tino_storm.search import _resolve_provider, search, search_async
+from tino_storm.search import _resolve_provider, search_async, search_sync
 from tino_storm.search_result import ResearchResult
 from tino_storm.events import ResearchAdded, event_emitter
 
@@ -241,7 +241,7 @@ def test_timeout_emits_event_and_skips_provider(monkeypatch):
     assert events[0].information_table["error"] == "timeout"
 
     events.clear()
-    sync_results = search("q", [], provider="slow,fast", timeout=0.01)
+    sync_results = search_sync("q", [], provider="slow,fast", timeout=0.01)
     assert {r.url for r in sync_results} == {"fast"}
     assert len(events) == 1
     assert events[0].topic == "slow"

--- a/tests/test_provider_errors.py
+++ b/tests/test_provider_errors.py
@@ -1,6 +1,6 @@
 import pytest
 from tino_storm.events import event_emitter, ResearchAdded
-from tino_storm.search import ResearchError, search
+from tino_storm.search import ResearchError, search_sync
 
 
 def test_bing_error_emits_event(monkeypatch):
@@ -88,7 +88,7 @@ def test_search_provider_exception_emits_event(monkeypatch):
             raise RuntimeError("boom")
 
     with pytest.raises(ResearchError):
-        search("topic", [], provider=StubProvider())
+        search_sync("topic", [], provider=StubProvider())
 
     assert len(events) == 1
     assert events[0].topic == "topic"

--- a/tests/test_provider_loading.py
+++ b/tests/test_provider_loading.py
@@ -12,7 +12,7 @@ from tino_storm.providers import (
 )
 from tino_storm.search import (
     _resolve_provider,
-    search as search_fn,
+    search_sync as search_fn,
     _PROVIDER_CACHE,
     ResearchError,
 )

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -31,5 +31,5 @@ def test_registry_retrieves_and_searches_with_custom_provider():
     provider = provider_registry.get("sample")
     assert isinstance(provider, SampleProvider)
 
-    results = tino_storm.search("query", [], provider="sample")
+    results = tino_storm.search_sync("query", [], provider="sample")
     assert results == [ResearchResult(url="custom", snippets=["ok"], meta={})]

--- a/tests/test_search_provider_failure.py
+++ b/tests/test_search_provider_failure.py
@@ -2,7 +2,7 @@ import pytest
 
 import tino_storm
 from tino_storm.events import ResearchAdded, event_emitter
-from tino_storm.search import ResearchError, search as search_func
+from tino_storm.search import ResearchError, search_sync as search_func
 
 
 def test_invalid_env_provider_emits_event(monkeypatch):
@@ -17,10 +17,10 @@ def test_invalid_env_provider_emits_event(monkeypatch):
     spec = "nonexistent.module.Provider"
     monkeypatch.setenv("STORM_SEARCH_PROVIDER", spec)
 
-    monkeypatch.setattr(tino_storm, "search", search_func)
+    monkeypatch.setattr(tino_storm, "search_sync", search_func)
 
     with pytest.raises(ResearchError) as exc:
-        tino_storm.search("topic", [])
+        tino_storm.search_sync("topic", [])
 
     assert exc.value.provider_spec == spec
     assert len(events) == 1

--- a/tests/test_search_vaults_timeout.py
+++ b/tests/test_search_vaults_timeout.py
@@ -7,7 +7,7 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from tino_storm.search import search, ResearchError  # noqa: E402
+from tino_storm.search import search_sync, ResearchError  # noqa: E402
 
 
 class SlowCollection:
@@ -33,4 +33,4 @@ def test_search_vaults_timeout(monkeypatch):
     )
 
     with pytest.raises(ResearchError):
-        search("q", ["v1"], timeout=0.05)
+        search_sync("q", ["v1"], timeout=0.05)


### PR DESCRIPTION
## Summary
- extract a dedicated `search_sync` helper while making the public `search` coroutine delegate to `search_async`
- update package exports, CLI, and API to use the new synchronous helper or await the async API
- align tests and fixtures with the asynchronous entrypoint and synchronous helper

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68c96f0dac5c8326a1eb1e34e39cf0ea