### PR TITLE
Add chromadb dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "litellm==1.59.3",
     "pytz",
     "httpx>=0.27.0,<0.29",
+    "chromadb",
 
     "requests>=2.31.0",
     "PyYAML>=6.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ trafilatura
 langchain-huggingface
 qdrant-client
 langchain-qdrant
+chromadb
 numpy==1.26.4
 litellm==1.59.3
 diskcache


### PR DESCRIPTION
## Summary
- add `chromadb` to the project dependency list
- sync `requirements.txt` so legacy packaging picks up the new dependency

## Testing
- pytest tests/test_encrypted_chroma.py
- ruff check src/tino_storm/security/encrypted_chroma.py

------
https://chatgpt.com/codex/tasks/task_e_68cacd96a44c8326a3be25ba74d330eb