### PR TITLE
Handle running loop in parallel provider sync

### DIFF
--- a/tests/test_parallel_provider_sync.py
+++ b/tests/test_parallel_provider_sync.py
@@ -1,0 +1,19 @@
+import asyncio
+
+from tino_storm.providers.parallel import ParallelProvider
+
+
+def test_parallel_provider_search_sync_inside_event_loop(monkeypatch):
+    monkeypatch.setattr(
+        "tino_storm.providers.parallel.search_vaults", lambda *args, **kwargs: []
+    )
+
+    provider = ParallelProvider()
+    monkeypatch.setattr(provider, "_bing_search", lambda query: [])
+
+    async def invoke_search_sync():
+        return provider.search_sync("query", ["vault"])
+
+    results = asyncio.run(invoke_search_sync())
+
+    assert results == []


### PR DESCRIPTION
## Summary
- update the parallel provider sync search path to avoid calling `asyncio.run` when an event loop is already running
- add a regression test covering `ParallelProvider.search_sync` when invoked from inside an asyncio loop

## Testing
- pytest tests/test_parallel_provider_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68d14966018c8326bbc1abeb1f86dfb4