### PR TITLE
Cache default search provider and support env var lists

### DIFF
--- a/docs/research_plugin.md
+++ b/docs/research_plugin.md
@@ -129,13 +129,20 @@ or the ``provider`` argument to ``search`` and ``search_async``.
 Multiple providers can be combined by passing a comma-separated list to the
 ``provider`` argument or the ``STORM_SEARCH_PROVIDER`` environment variable. The
 list is resolved into a ``ProviderAggregator`` which queries each provider and
-merges their results.
+merges their results. Whitespace around provider names is ignored, so both
+``"docs_hub,parallel"`` and ``"docs_hub, parallel"`` produce the same
+aggregation. When configured via ``STORM_SEARCH_PROVIDER`` the resulting
+provider is cached so repeated searches reuse any internal state.
 
 ```python
 results = await tino_storm.search_async(
     "large language models",
     provider="default,my-provider",
 )
+```
+
+```bash
+export STORM_SEARCH_PROVIDER="docs_hub, parallel"
 ```
 
 ## Error handling

--- a/tests/test_search_provider_cache.py
+++ b/tests/test_search_provider_cache.py
@@ -1,0 +1,40 @@
+import pytest
+
+import tino_storm.search as search_module
+from tino_storm.providers import ProviderAggregator
+
+
+def _clear_provider_cache():
+    with search_module._PROVIDER_CACHE_LOCK:
+        search_module._PROVIDER_CACHE.clear()
+
+
+def test_default_provider_is_cached(monkeypatch):
+    monkeypatch.delenv("STORM_SEARCH_PROVIDER", raising=False)
+    _clear_provider_cache()
+
+    first = search_module._resolve_provider(None)
+    second = search_module._resolve_provider(None)
+
+    assert first is second
+
+
+@pytest.mark.parametrize(
+    "env_value",
+    [
+        "docs_hub,parallel",
+        "docs_hub, parallel",
+    ],
+)
+def test_env_provider_list_builds_aggregator(monkeypatch, env_value):
+    _clear_provider_cache()
+    monkeypatch.setenv("STORM_SEARCH_PROVIDER", env_value)
+
+    provider = search_module._resolve_provider(None)
+
+    assert isinstance(provider, ProviderAggregator)
+    assert len(provider.providers) == 2
+    assert search_module._resolve_provider(None) is provider
+
+    monkeypatch.delenv("STORM_SEARCH_PROVIDER")
+


### PR DESCRIPTION
## Summary
- cache the default research provider instance so Bing and summarization state persist across searches
- allow STORM_SEARCH_PROVIDER to accept comma-separated values using the same aggregator logic as the provider argument
- add regression tests for provider caching and aggregated environment configuration plus document the comma-separated syntax

## Testing
- pytest tests/test_search_provider_cache.py tests/test_search_provider_failure.py

------
https://chatgpt.com/codex/tasks/task_e_68dd28b13ce08326b35e9f6c0db41450