### PR TITLE
Handle module calls in async contexts

### DIFF
--- a/tests/test_module_callable.py
+++ b/tests/test_module_callable.py
@@ -1,5 +1,7 @@
 import importlib
 
+import pytest
+
 import tino_storm
 
 
@@ -18,3 +20,26 @@ def test_module_callable(monkeypatch):
 
     assert result == "result"
     assert calls == {"query": "my query", "kwargs": {"foo": "bar"}}
+
+
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], scope="module")
+@pytest.mark.anyio
+async def test_module_callable_async(monkeypatch, anyio_backend):
+    calls = {}
+
+    async def fake_search(query, **kwargs):
+        calls["query"] = query
+        calls["kwargs"] = kwargs
+        return "async result"
+
+    def fake_search_sync(*args, **kwargs):
+        raise AssertionError("search_sync should not be used when an event loop is running")
+
+    search_mod = importlib.import_module("tino_storm.search")
+    monkeypatch.setattr(search_mod, "search", fake_search)
+    monkeypatch.setattr(search_mod, "search_sync", fake_search_sync)
+
+    result = await tino_storm("async query", foo="baz")
+
+    assert result == "async result"
+    assert calls == {"query": "async query", "kwargs": {"foo": "baz"}}


### PR DESCRIPTION
## Summary
- detect running event loops when calling the tino_storm module so async callers receive the coroutine from `search`
- share the call-dispatch logic between the module-level callable and its module subclass
- extend module callable tests to cover both synchronous and asynchronous invocation paths

## Testing
- `pytest tests/test_module_callable.py`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_68dd28b06094832681a172cd418e40eb