### PR TITLE
Ensure Bing async provider honors timeout parameter

### DIFF
--- a/src/tino_storm/providers/bing_async.py
+++ b/src/tino_storm/providers/bing_async.py
@@ -34,9 +34,14 @@ class BingAsyncProvider(Provider):
             return []
         headers = {"Ocp-Apim-Subscription-Key": api_key}
         params = {"q": query, "count": k_per_vault}
+        timeout_value = 10.0 if timeout is None else timeout
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.get(BING_ENDPOINT, params=params, headers=headers)
+            async with httpx.AsyncClient(timeout=timeout_value) as client:
+                resp = await client.get(
+                    BING_ENDPOINT,
+                    params=params,
+                    headers=headers,
+                )
                 resp.raise_for_status()
                 data = resp.json()
         except httpx.HTTPError as exc:


### PR DESCRIPTION
## Summary
- ensure the Bing async provider forwards the caller-provided timeout when creating the HTTP client
- add a regression test that confirms the custom timeout propagates through to httpx.AsyncClient

## Testing
- pytest tests/test_bing_async_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68de811059e483269f0af643ba6ac7d1