### PR TITLE
Enhance provider aggregator with reciprocal rank fusion

### DIFF
--- a/docs/research_plugin.md
+++ b/docs/research_plugin.md
@@ -134,6 +134,15 @@ merges their results. Whitespace around provider names is ignored, so both
 aggregation. When configured via ``STORM_SEARCH_PROVIDER`` the resulting
 provider is cached so repeated searches reuse any internal state.
 
+The aggregator applies Reciprocal Rank Fusion (RRF) to re-rank the combined
+results, ensuring that high-ranking documents from any provider float to the
+top while still deduplicating URLs. When duplicates appear, the aggregator
+keeps the richest metadata available—preferring longer summaries and the
+highest ``score``/``posterior`` values. The ``k_per_vault`` argument continues to
+control how many fused items are returned, while ``rrf_k`` tunes both the RRF
+decay constant and the post-fusion trim (the aggregator returns up to
+``min(k_per_vault, rrf_k)`` items).
+
 ```python
 results = await tino_storm.search_async(
     "large language models",


### PR DESCRIPTION
## Summary
- fuse provider outputs with Reciprocal Rank Fusion while preserving the best metadata for duplicate URLs
- cover mixed provider scores and aggregation trimming in unit tests
- document the new fusion behavior and configuration knobs in the research plugin guide

## Testing
- pytest tests/test_provider_aggregator.py

------
https://chatgpt.com/codex/tasks/task_e_68de918928788326b4de7a2bf8e25d4c