### PR TITLE
Refactor optional LLM dependencies into extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ which tino-storm
 
 `tino-storm` exposes a couple of optional dependency groups:
 
+- **llm** – installs LiteLLM, DSPy and related tooling used for summarisation
+  and collaborative research flows.
+
+  ```bash
+  pip install tino-storm[llm]
+  ```
+
 - **scrapers** – enable the ingestion helpers for scraping social platforms and PDF files.
 
   ```bash
@@ -42,6 +49,7 @@ which tino-storm
   ```
 
 - **research** – install the FastAPI server and filesystem watcher used by the CLI.
+  This extra also pulls in the ``llm`` dependencies for convenience.
   The `watchdog` dependency required for directory watching ships with this
   extra, and the CLI will prompt you to install it automatically whenever a
   command needs it.

--- a/docs/research_plugin.md
+++ b/docs/research_plugin.md
@@ -5,6 +5,7 @@ language-model agents to query one or more STORM vaults. Install optional
 extras to pull in additional features:
 
 ```bash
+pip install tino-storm[llm]       # LiteLLM, DSPy and summarisation helpers
 pip install tino-storm[research]  # FastAPI server and filesystem watcher
 pip install tino-storm[scrapers]  # ingestion helpers for social platforms
 pip install tino-storm[retrieval] # semantic search and vector DB helpers
@@ -28,7 +29,8 @@ The search API returns a list of `ResearchResult` objects containing the URL,
 text snippets, optional metadata and a short summary from the retrieved
 documents. By default the first snippet is used as the summary. If the
 `STORM_SUMMARY_MODEL` environment variable is set, that model will be invoked
-to generate a one-sentence summary for each result. The optional
+to generate a one-sentence summary for each result. Install the ``llm`` extra
+to pull in the LiteLLM integration required for this feature. The optional
 `STORM_SUMMARY_TIMEOUT` variable limits how long the summarizer is allowed to
 run before the first snippet is used as a fallback.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,9 @@ description = "STORM: A language model-powered knowledge curation engine."
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "dspy_ai==2.4.9",
-    "wikipedia==1.4.0",
     "toml",
     "trafilatura",
     "numpy==1.26.4",
-    "litellm==1.59.3",
     "pytz",
     "httpx>=0.27.0,<0.29",
     "chromadb",
@@ -27,13 +24,27 @@ tino-storm = "tino_storm.cli:main"
 bing_async = "tino_storm.providers.bing_async:BingAsyncProvider"
 
 [project.optional-dependencies]
+llm = [
+    "backoff>=2.2.1",
+    "dspy_ai==2.4.9",
+    "litellm==1.59.3",
+    "openai>=1.0.0",
+    "transformers>=4.38.0",
+    "ujson>=5.9.0",
+]
 scrapers = [
     "snscrape",
     "praw",
     "pypdf",
 ]
 research = [
+    "backoff>=2.2.1",
+    "dspy_ai==2.4.9",
     "fastapi>=0.110.0",
+    "litellm==1.59.3",
+    "openai>=1.0.0",
+    "transformers>=4.38.0",
+    "ujson>=5.9.0",
     "uvicorn>=0.29.0",
     "watchdog",
     "knowledge-storm",

--- a/src/tino_storm/__init__.py
+++ b/src/tino_storm/__init__.py
@@ -1,7 +1,4 @@
-"""Top-level package for ``tino_storm``.
-
-Primary classes are exposed here via lazy imports to avoid heavy
-dependencies unless needed."""
+"""Top-level package for ``tino_storm`` with optional dependency helpers."""
 
 import asyncio
 from importlib import import_module
@@ -9,8 +6,17 @@ import sys
 from types import ModuleType
 from typing import TYPE_CHECKING
 
+from ._extras import ensure_optional_dependency_stub
+
 if TYPE_CHECKING:  # pragma: no cover
     from .search import search, search_sync
+
+# Register helpful stubs for optional dependencies so that modules importing
+# DSPy-related helpers raise ``MissingExtraError`` with installation guidance
+# instead of failing with a bare ``ModuleNotFoundError`` when the ``llm`` extra
+# is not installed.
+ensure_optional_dependency_stub("dspy", "llm")
+ensure_optional_dependency_stub("dspy.teleprompt", "llm")
 
 __all__ = [
     "__version__",

--- a/src/tino_storm/_extras.py
+++ b/src/tino_storm/_extras.py
@@ -1,0 +1,90 @@
+"""Helpers for managing optional dependencies.
+
+This module centralises the logic used across the codebase for importing
+optional packages.  Heavy integrations such as LiteLLM and DSPy are moved to
+extras so the baseline vault search experience only pulls lightweight
+dependencies.  When one of those extras is missing we raise a descriptive error
+that explains how to install the required extra instead of exposing a generic
+``ModuleNotFoundError``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from types import ModuleType
+
+__all__ = ["MissingExtraError", "require_extra", "ensure_optional_dependency_stub"]
+
+
+class MissingExtraError(ImportError):
+    """Raised when an optional dependency is accessed without its extra."""
+
+    def __init__(self, package: str, extra: str) -> None:
+        message = (
+            f"The optional dependency '{package}' is required for this feature. "
+            f"Install it with `pip install tino-storm[{extra}]`."
+        )
+        super().__init__(message)
+        self.package = package
+        self.extra = extra
+
+
+def require_extra(module: str, extra: str, *, package: str | None = None) -> ModuleType:
+    """Import *module* raising :class:`MissingExtraError` on failure.
+
+    Parameters
+    ----------
+    module:
+        The fully qualified module name to import.
+    extra:
+        The name of the optional extra that installs the dependency.
+    package:
+        Optional name of the PyPI package providing *module*.  When omitted the
+        top-level module name is used.
+    """
+
+    target = package or module.split(".", 1)[0]
+
+    try:
+        return importlib.import_module(module)
+    except ModuleNotFoundError as exc:
+        if exc.name == target or exc.name == module:
+            raise MissingExtraError(target, extra) from exc
+        raise
+
+
+def ensure_optional_dependency_stub(module: str, extra: str) -> None:
+    """Register a lightweight stub that surfaces :class:`MissingExtraError`.
+
+    The stub behaves like a namespace package so that ``import foo.bar`` works
+    even when ``foo`` is missing.  Accessing any attribute of the stub raises a
+    ``MissingExtraError`` explaining which extra to install.
+    """
+
+    if module in sys.modules:
+        return
+
+    spec = importlib.util.find_spec(module)
+    if spec is not None:  # The real module is available; do nothing.
+        return
+
+    parent_name, _, _child = module.rpartition(".")
+    if parent_name:
+        ensure_optional_dependency_stub(parent_name, extra)
+        parent = sys.modules[parent_name]
+        if not hasattr(parent, "__path__"):
+            parent.__path__ = []  # type: ignore[attr-defined]
+
+    stub = ModuleType(module)
+    package_name = module.split(".", 1)[0]
+
+    def _missing_attr(_name: str) -> None:
+        raise MissingExtraError(package_name, extra)
+
+    stub.__getattr__ = _missing_attr  # type: ignore[attr-defined]
+    stub.__all__ = []  # type: ignore[attr-defined]
+    stub.__path__ = []  # type: ignore[attr-defined]
+    sys.modules[module] = stub
+

--- a/src/tino_storm/lm.py
+++ b/src/tino_storm/lm.py
@@ -1,23 +1,33 @@
-import backoff
-import dspy
+from __future__ import annotations
+
 import functools
 import logging
 import os
 import random
-import requests
 import threading
-from typing import Optional, Literal, Any
-import ujson
 from pathlib import Path
+from typing import Any, Literal, Optional
 
+import requests
+
+from ._extras import require_extra
 from .security import log_request
 
-
-from dsp import ERRORS, backoff_hdlr, giveup_hdlr
-from dsp.modules.hf import openai_to_hf
-from dsp.modules.hf_client import send_hftgi_request_v01_wrapped
-from openai import OpenAI, AzureOpenAI
-from transformers import AutoTokenizer
+backoff = require_extra("backoff", "llm")
+dspy = require_extra("dspy", "llm")
+dsp = require_extra("dsp", "llm")
+ERRORS = dsp.ERRORS
+backoff_hdlr = dsp.backoff_hdlr
+giveup_hdlr = dsp.giveup_hdlr
+openai_module = require_extra("openai", "llm")
+OpenAI = openai_module.OpenAI
+AzureOpenAI = openai_module.AzureOpenAI
+_dsp_hf = require_extra("dsp.modules.hf", "llm", package="dsp")
+openai_to_hf = _dsp_hf.openai_to_hf
+_dsp_hf_client = require_extra("dsp.modules.hf_client", "llm", package="dsp")
+send_hftgi_request_v01_wrapped = _dsp_hf_client.send_hftgi_request_v01_wrapped
+AutoTokenizer = require_extra("transformers", "llm").AutoTokenizer
+ujson = require_extra("ujson", "llm")
 
 try:
     from anthropic import RateLimitError
@@ -34,12 +44,12 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=UserWarning)
     if "LITELLM_LOCAL_MODEL_COST_MAP" not in os.environ:
         os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    import litellm
+    litellm = require_extra("litellm", "llm")
 
     litellm.drop_params = True
     litellm.telemetry = False
 
-from litellm.caching.caching import Cache
+Cache = require_extra("litellm.caching.caching", "llm", package="litellm").Cache
 
 disk_cache_dir = os.path.join(Path.home(), ".storm_local_cache")
 litellm.cache = Cache(disk_cache_dir=disk_cache_dir, type="disk")

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,68 @@
+import importlib
+import sys
+
+import pytest
+
+from tino_storm._extras import MissingExtraError
+
+
+@pytest.fixture
+def _restore_module_cache():
+    """Ensure modified modules are reloaded after each test."""
+
+    original_modules = sys.modules.copy()
+    yield
+    for name in list(sys.modules):
+        if name not in original_modules:
+            sys.modules.pop(name)
+
+
+def _simulate_missing(monkeypatch, prefix: str) -> None:
+    """Force optional dependency *prefix* to appear missing."""
+
+    for name in list(sys.modules):
+        if name == prefix or name.startswith(prefix + "."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):  # pragma: no cover - passthrough
+        if name == prefix or name.startswith(prefix + "."):
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, package=None):  # pragma: no cover - passthrough
+        if name == prefix or name.startswith(prefix + "."):
+            raise ModuleNotFoundError(name=prefix)
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+
+def test_lm_missing_llm_extra(monkeypatch, _restore_module_cache):
+    _simulate_missing(monkeypatch, "litellm")
+    monkeypatch.delitem(sys.modules, "tino_storm.lm", raising=False)
+
+    with pytest.raises(MissingExtraError) as excinfo:
+        importlib.import_module("tino_storm.lm")
+
+    assert "pip install tino-storm[llm]" in str(excinfo.value)
+
+
+def test_research_skill_missing_dspy(monkeypatch, _restore_module_cache):
+    _simulate_missing(monkeypatch, "dspy")
+    for name in [
+        "tino_storm",
+        "tino_storm.skills",
+        "tino_storm.skills.research",
+        "tino_storm.skills.research_module",
+    ]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    with pytest.raises(MissingExtraError) as excinfo:
+        importlib.import_module("tino_storm.skills.research")
+
+    assert "pip install tino-storm[llm]" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- move LiteLLM and DSPy into a dedicated `llm` extra and extend existing extras to depend on it
- add optional dependency helpers with informative errors and update modules to use them
- document the new extras and add regression tests covering missing LLM dependencies

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68de9559b6748326aa756e77e8bb73de