### PR TITLE
Avoid duplicate local search launches when Docs Hub already handles fallback

### DIFF
--- a/src/tino_storm/providers/multi_source.py
+++ b/src/tino_storm/providers/multi_source.py
@@ -32,16 +32,25 @@ class MultiSourceProvider(DefaultProvider):
         vault: Optional[str] = None,
         timeout: Optional[float] = None,
     ) -> List[ResearchResult]:
-        vault_task = asyncio.to_thread(
-            search_vaults,
-            query,
-            vaults,
-            k_per_vault=k_per_vault,
-            rrf_k=rrf_k,
-            chroma_path=chroma_path,
-            vault=vault,
-            timeout=timeout,
-        )
+        tasks = []
+        task_names: List[str] = []
+
+        docs_will_handle_local = not self.docs_provider.is_remote_configured
+
+        if not docs_will_handle_local:
+            vault_task = asyncio.to_thread(
+                search_vaults,
+                query,
+                vaults,
+                k_per_vault=k_per_vault,
+                rrf_k=rrf_k,
+                chroma_path=chroma_path,
+                vault=vault,
+                timeout=timeout,
+            )
+            tasks.append(vault_task)
+            task_names.append("vault")
+
         docs_task = self.docs_provider.search_async(
             query,
             vaults,
@@ -51,11 +60,30 @@ class MultiSourceProvider(DefaultProvider):
             vault=vault,
             timeout=timeout,
         )
-        bing_task = asyncio.to_thread(self._bing_search, query)
+        tasks.append(docs_task)
+        task_names.append("docs")
 
-        vault_res, docs_res, bing_res = await asyncio.gather(
-            vault_task, docs_task, bing_task, return_exceptions=True
+        bing_task = asyncio.to_thread(self._bing_search, query)
+        tasks.append(bing_task)
+        task_names.append("bing")
+
+        gathered_results = await asyncio.gather(*tasks, return_exceptions=True)
+        results_map = dict(zip(task_names, gathered_results))
+
+        vault_res = results_map.get("vault") if "vault" in results_map else None
+        docs_res = results_map.get("docs")
+        bing_res = results_map.get("bing")
+
+        docs_used_local = (
+            not isinstance(docs_res, Exception)
+            and bool(docs_res)
+            and all(
+                getattr(r, "meta", {}).get("docs_hub_origin") == "local" for r in docs_res
+            )
         )
+
+        if docs_used_local:
+            vault_res = None
 
         rankings: List[List[Dict[str, Any]]] = []
 
@@ -64,6 +92,8 @@ class MultiSourceProvider(DefaultProvider):
             ("docs", docs_res),
             ("bing", bing_res),
         ):
+            if res is None:
+                continue
             if isinstance(res, Exception):
                 logging.exception("%s search failed in MultiSourceProvider", source)
                 await event_emitter.emit(

--- a/tests/test_multi_source_provider.py
+++ b/tests/test_multi_source_provider.py
@@ -24,6 +24,7 @@ def test_multi_source_provider_queries_all_sources(monkeypatch):
     )
 
     provider = MultiSourceProvider()
+    provider.docs_provider._client = type("Client", (), {"is_configured": True})()
     monkeypatch.setattr(
         provider,
         "_bing_search",
@@ -66,6 +67,7 @@ def test_multi_source_provider_handles_source_failure(monkeypatch):
     )
 
     provider = MultiSourceProvider()
+    provider.docs_provider._client = type("Client", (), {"is_configured": True})()
 
     def raise_bing(_q: str):
         raise RuntimeError("boom")
@@ -88,6 +90,37 @@ def test_multi_source_provider_handles_source_failure(monkeypatch):
     assert events[0].information_table["error"] == "boom"
 
 
+def test_multi_source_provider_skips_duplicate_local_search(monkeypatch):
+    call_count = 0
+
+    async def fake_to_thread(func, *a, **k):
+        return func(*a, **k)
+
+    def fake_search_vaults(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return [{"url": "vault", "snippets": [], "meta": {}}]
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(
+        "tino_storm.providers.multi_source.search_vaults", fake_search_vaults
+    )
+    monkeypatch.setattr("tino_storm.providers.docs_hub.search_vaults", fake_search_vaults)
+
+    provider = MultiSourceProvider()
+    provider.docs_provider._client = None
+
+    monkeypatch.setattr(provider, "_bing_search", lambda q: [])
+
+    async def run():
+        return await provider.search_async("query", ["vault"])
+
+    results = asyncio.run(run())
+
+    assert call_count == 1
+    assert {r.url for r in results} == {"vault"}
+
+
 def test_multi_source_provider_search_sync_in_running_loop(monkeypatch):
     async def fake_to_thread(func, *a, **k):
         return func(*a, **k)
@@ -99,6 +132,7 @@ def test_multi_source_provider_search_sync_in_running_loop(monkeypatch):
     )
 
     provider = MultiSourceProvider()
+    provider.docs_provider._client = type("Client", (), {"is_configured": True})()
     monkeypatch.setattr(
         provider,
         "_bing_search",


### PR DESCRIPTION
## Summary
- expose an `is_remote_configured` helper and origin tagging inside `DocsHubProvider`
- update `MultiSourceProvider` to skip redundant local search tasks and to drop duplicate local rankings when Docs Hub falls back
- add a regression test ensuring only one `search_vaults` call is triggered when Docs Hub runs in local mode

## Testing
- pytest tests/test_multi_source_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68e3d9c3d45483269f448aa8c88bad08