### PR TITLE
Fix docs hub result handling in multi-source provider

### DIFF
--- a/src/tino_storm/providers/multi_source.py
+++ b/src/tino_storm/providers/multi_source.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Iterable, List, Dict, Any, Optional, Set
+from typing import Any, Dict, Iterable, List, Optional, Set
 
 from .aggregator import canonical_url, _update_best_metadata
-from .base import DefaultProvider, format_bing_items, _run_coroutine_in_new_loop
-from .aggregator import canonical_url, _update_best_metadata
+from .base import DefaultProvider, _run_coroutine_in_new_loop, format_bing_items
 from .docs_hub import DocsHubProvider
 from .registry import register_provider
 from ..events import ResearchAdded, event_emitter
@@ -155,27 +154,12 @@ class MultiSourceProvider(DefaultProvider):
                     annotated_vault.append(as_research_result(entry))
                 add_ranked_results(annotated_vault)
             elif source == "docs" and res:
-                formatted_docs: List[ResearchResult] = []
+                docs_results: List[ResearchResult] = []
                 for r in res:
-                    info: Dict[str, Any] = {
-                        "url": r.url,
-                        "snippets": r.snippets,
-                        "meta": dict(r.meta),
-                    }
-                    info["meta"].setdefault("source", "docs_hub")
-                    _ensure_provenance(info["meta"], "docs_hub")
-                    if r.summary is not None:
-                        info["summary"] = r.summary
-                    if r.score is not None:
-                        info["score"] = r.score
-                    if r.posterior is not None:
-                        info["posterior"] = r.posterior
-                    formatted_docs.append(info)
-
-                rankings.append(formatted_docs)
                     meta = dict(r.meta) if r.meta else {}
                     meta.setdefault("source", "docs_hub")
-                    formatted_docs.append(
+                    _ensure_provenance(meta, "docs_hub")
+                    docs_results.append(
                         ResearchResult(
                             url=r.url,
                             snippets=list(r.snippets),
@@ -186,11 +170,12 @@ class MultiSourceProvider(DefaultProvider):
                         )
                     )
 
-                add_ranked_results(formatted_docs)
+                add_ranked_results(docs_results)
             elif source == "bing":
                 formatted = format_bing_items(res)
                 for item in formatted:
                     meta = dict(item.get("meta") or {})
+                    meta.setdefault("source", "bing")
                     _ensure_provenance(meta, "bing")
                     item["meta"] = meta
                 if formatted:
@@ -201,35 +186,28 @@ class MultiSourceProvider(DefaultProvider):
         if not canonical_to_result:
             return []
 
-        fused = reciprocal_rank_fusion(rankings, k=rrf_k)
-        scored = add_posteriors(fused)
-        results = [as_research_result(r) for r in scored]
-
-        deduped: Dict[str, ResearchResult] = {}
-        order: List[str] = []
-        for result in results:
-            key = canonical_url(result.url) if result.url else result.url
-            if key not in deduped:
-                deduped[key] = result
-                order.append(key)
-            else:
-                _update_best_metadata(deduped[key], result)
-
-        return [deduped[key] for key in order]
-        ordered_results: List[ResearchResult]
+        ordered_keys: List[str]
         if rankings:
             fused = reciprocal_rank_fusion(rankings, k=rrf_k)
-            ordered_results = [
-                canonical_to_result[entry["url"]]
+            ordered_keys = [
+                entry["url"]
                 for entry in fused
                 if entry.get("url") in canonical_to_result
             ]
         else:
-            ordered_results = list(canonical_to_result.values())
+            ordered_keys = list(canonical_to_result.keys())
 
-        limit = min(k_per_vault, rrf_k) if k_per_vault is not None else rrf_k
-        if limit is not None and limit >= 0:
-            ordered_results = ordered_results[:limit]
+        seen: Set[str] = set()
+        ordered_results: List[ResearchResult] = []
+        for key in ordered_keys:
+            if key in seen:
+                continue
+            seen.add(key)
+            ordered_results.append(canonical_to_result[key])
+
+        for key, result in canonical_to_result.items():
+            if key not in seen:
+                ordered_results.append(result)
 
         serialized = [
             {
@@ -242,14 +220,18 @@ class MultiSourceProvider(DefaultProvider):
             }
             for result in ordered_results
         ]
-        scored = add_posteriors(serialized)
-        for idx, result in enumerate(ordered_results):
-            if result.posterior is not None and scored[idx].get("posterior") is not None:
-                scored[idx]["posterior"] = max(
-                    result.posterior, scored[idx]["posterior"]
-                )
 
-        return [as_research_result(r) for r in scored]
+        scored = add_posteriors(serialized)
+        for result, scored_data in zip(ordered_results, scored):
+            posterior = scored_data.get("posterior")
+            if posterior is None:
+                continue
+            if result.posterior is None:
+                result.posterior = posterior
+            else:
+                result.posterior = max(result.posterior, posterior)
+
+        return ordered_results
 
     def search_sync(
         self,

--- a/tests/stubs/backoff.py
+++ b/tests/stubs/backoff.py
@@ -1,0 +1,12 @@
+__all__ = ["on_exception", "expo"]
+
+
+def on_exception(*args, **kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+def expo(*args, **kwargs):
+    return 0

--- a/tests/stubs/dsp/__init__.py
+++ b/tests/stubs/dsp/__init__.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace, ModuleType
+
+__all__ = [
+    "LM",
+    "HFModel",
+    "OpenAI",
+    "OllamaLocal",
+    "OllamaClient",
+    "HFClientTGI",
+    "Together",
+    "Retrieve",
+    "Signature",
+    "Module",
+    "Predict",
+    "Prediction",
+    "ChainOfThought",
+    "InputField",
+    "OutputField",
+    "settings",
+    "ERRORS",
+    "backoff_hdlr",
+    "giveup_hdlr",
+    "modules",
+]
+
+
+class LM:
+    pass
+
+
+class HFModel:
+    pass
+
+
+class OpenAI:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class OllamaLocal:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class OllamaClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class HFClientTGI:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class Together:
+    pass
+
+
+class Retrieve:
+    def __init__(self, k: int = 3, **kwargs):
+        self.k = k
+
+    def __call__(self, *args, **kwargs):
+        return []
+
+
+class Signature:
+    pass
+
+
+class Module:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class Predict:
+    def __init__(self, *args, **kwargs):
+        self.result = SimpleNamespace()
+
+    def __call__(self, *args, **kwargs):
+        return self.result
+
+
+class Prediction(SimpleNamespace):
+    pass
+
+
+class ChainOfThought(Predict):
+    pass
+
+
+class InputField:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class OutputField(InputField):
+    pass
+
+
+class settings:
+    class context:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *args):
+            return False
+
+
+def backoff_hdlr(*args, **kwargs):
+    pass
+
+
+def giveup_hdlr(*args, **kwargs):
+    return False
+
+
+ERRORS = Exception
+
+modules = ModuleType("dsp.modules")
+modules.hf = ModuleType("dsp.modules.hf")
+modules.hf_client = ModuleType("dsp.modules.hf_client")
+modules.lm = ModuleType("dsp.modules.lm")
+modules.lm.LM = LM

--- a/tests/stubs/dsp/modules/__init__.py
+++ b/tests/stubs/dsp/modules/__init__.py
@@ -1,0 +1,3 @@
+from . import hf, hf_client, lm
+
+__all__ = ["hf", "hf_client", "lm"]

--- a/tests/stubs/dsp/modules/hf.py
+++ b/tests/stubs/dsp/modules/hf.py
@@ -1,0 +1,5 @@
+__all__ = ["openai_to_hf"]
+
+
+def openai_to_hf(*args, **kwargs):
+    pass

--- a/tests/stubs/dsp/modules/hf_client.py
+++ b/tests/stubs/dsp/modules/hf_client.py
@@ -1,0 +1,5 @@
+__all__ = ["send_hftgi_request_v01_wrapped"]
+
+
+def send_hftgi_request_v01_wrapped(*args, **kwargs):
+    pass

--- a/tests/stubs/dsp/modules/lm.py
+++ b/tests/stubs/dsp/modules/lm.py
@@ -1,0 +1,3 @@
+from .. import LM
+
+__all__ = ["LM"]

--- a/tests/stubs/dspy/__init__.py
+++ b/tests/stubs/dspy/__init__.py
@@ -1,0 +1,122 @@
+from types import SimpleNamespace
+
+import importlib
+
+__all__ = [
+    "OpenAI",
+    "LM",
+    "HFModel",
+    "OllamaLocal",
+    "OllamaClient",
+    "HFClientTGI",
+    "Together",
+    "Retrieve",
+    "Signature",
+    "Module",
+    "Predict",
+    "Prediction",
+    "ChainOfThought",
+    "InputField",
+    "OutputField",
+    "settings",
+    "dsp",
+]
+
+
+class OpenAI:
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+
+
+class LM:
+    pass
+
+
+class HFModel:
+    pass
+
+
+class OllamaLocal:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class OllamaClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class HFClientTGI:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class Together:
+    pass
+
+
+class Retrieve:
+    def __init__(self, k: int = 3, **kwargs):
+        self.k = k
+
+    def __call__(self, *args, **kwargs):
+        return []
+
+
+class Signature:
+    pass
+
+
+class Module:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class Predict:
+    def __init__(self, *args, **kwargs):
+        self.result = SimpleNamespace()
+
+    def __call__(self, *args, **kwargs):
+        return self.result
+
+
+class Prediction(SimpleNamespace):
+    pass
+
+
+class ChainOfThought(Predict):
+    pass
+
+
+class InputField:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class OutputField(InputField):
+    pass
+
+
+class settings:
+    class context:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *args):
+            return False
+
+
+def backoff_hdlr(*args, **kwargs):
+    pass
+
+
+def giveup_hdlr(*args, **kwargs):
+    return False
+
+
+ERRORS = Exception
+
+dsp = importlib.import_module("dsp")

--- a/tests/stubs/litellm/__init__.py
+++ b/tests/stubs/litellm/__init__.py
@@ -1,0 +1,15 @@
+from types import SimpleNamespace
+
+__all__ = ["completion", "text_completion", "drop_params", "telemetry", "cache"]
+
+drop_params = False
+telemetry = False
+cache = None
+
+
+def completion(*args, **kwargs):
+    return {"choices": [{"message": SimpleNamespace(content="")}] , "usage": {}}
+
+
+def text_completion(*args, **kwargs):
+    return {"choices": [{"text": ""}], "usage": {}}

--- a/tests/stubs/litellm/caching/__init__.py
+++ b/tests/stubs/litellm/caching/__init__.py
@@ -1,0 +1,3 @@
+from . import caching
+
+__all__ = ["caching"]

--- a/tests/stubs/litellm/caching/caching.py
+++ b/tests/stubs/litellm/caching/caching.py
@@ -1,0 +1,5 @@
+__all__ = ["Cache"]
+
+
+def Cache(*args, **kwargs):
+    return None

--- a/tests/stubs/openai.py
+++ b/tests/stubs/openai.py
@@ -1,0 +1,11 @@
+__all__ = ["OpenAI", "AzureOpenAI"]
+
+
+class OpenAI:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class AzureOpenAI:
+    def __init__(self, *args, **kwargs):
+        pass

--- a/tests/stubs/transformers/__init__.py
+++ b/tests/stubs/transformers/__init__.py
@@ -1,0 +1,10 @@
+__all__ = ["AutoTokenizer"]
+
+
+class AutoTokenizer:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return cls()
+
+    def __call__(self, text):
+        return text

--- a/tests/stubs/ujson.py
+++ b/tests/stubs/ujson.py
@@ -1,0 +1,11 @@
+import json
+
+__all__ = ["dumps", "loads"]
+
+
+def dumps(obj, *args, **kwargs):
+    return json.dumps(obj)
+
+
+def loads(s, *args, **kwargs):
+    return json.loads(s)


### PR DESCRIPTION
## Summary
- ensure the multi-source provider converts Docs Hub hits into `ResearchResult` instances, preserves provenance, and deduplicates typed results
- add a regression test that exercises Docs Hub responses built from `ResearchResult` objects end-to-end
- provide lightweight stubs for optional LLM dependencies so the regression can run without heavy extras

## Testing
- PYTHONPATH=tests/stubs:src pytest tests/test_multi_source_provider.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163dee3c20832686d2f9cce55f035e)