### PR TITLE
Add TaskCascadence integration adapter and packaging metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,29 @@ which tino-storm
   pip install tino-storm[research]
   ```
 
+## TaskCascadence integration
+
+Deployers that only need a lightweight callable/search surface for
+TaskCascadence can import the adapter in ``tino_storm.cascadence`` without
+pulling in the CLI or FastAPI service stack:
+
+```python
+from tino_storm.cascadence import adapter
+
+# Synchronous or async dispatch based on the current loop
+results = adapter("quantum computing", vaults=["science"])
+
+# Explicit coroutines for orchestrators that manage their own loop
+results = await adapter.search("quantum computing", vaults=["science"])
+```
+
+Install just this integration via the dedicated extra to avoid the CLI/service
+dependencies:
+
+```bash
+pip install tino-storm[cascadence]
+```
+
 ## Command line usage
 
 `tino-storm` provides a simple CLI.  The `run` sub-command executes a single

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ tino-storm = "tino_storm.cli:main"
 [project.entry-points."tino_storm.providers"]
 bing_async = "tino_storm.providers.bing_async:BingAsyncProvider"
 
+[project.entry-points."task_cascadence.integrations"]
+tino_storm = "tino_storm.cascadence:adapter"
+
 [project.optional-dependencies]
 llm = [
     "backoff>=2.2.1",
@@ -49,6 +52,7 @@ research = [
     "watchdog",
     "knowledge-storm",
 ]
+cascadence = []
 retrieval = [
     "sentence-transformers",
     "langchain-text-splitters",

--- a/src/tino_storm/cascadence.py
+++ b/src/tino_storm/cascadence.py
@@ -1,0 +1,115 @@
+"""Lightweight adapter for TaskCascadence orchestrations.
+
+This module re-exports the minimal search helpers without pulling in the CLI
+stack, making it safe to import as a plugin in orchestration environments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable, List, Optional
+
+from .search import search as _search
+from .search import search_async as _search_async
+from .search import search_sync as _search_sync
+from .search_result import ResearchResult
+
+__all__ = [
+    "adapter",
+    "CascadenceAdapter",
+    "search",
+    "search_async",
+    "search_sync",
+]
+
+
+class CascadenceAdapter:
+    """Thin wrapper exposing the TaskCascadence call/search surface."""
+
+    def __call__(
+        self,
+        query: str,
+        vaults: Iterable[str] | None = None,
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+        provider=None,
+        timeout: Optional[float] = None,
+    ):
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return _search_sync(
+                query,
+                vaults,
+                k_per_vault=k_per_vault,
+                rrf_k=rrf_k,
+                chroma_path=chroma_path,
+                vault=vault,
+                provider=provider,
+                timeout=timeout,
+            )
+        return _search(
+            query,
+            vaults,
+            k_per_vault=k_per_vault,
+            rrf_k=rrf_k,
+            chroma_path=chroma_path,
+            vault=vault,
+            provider=provider,
+            timeout=timeout,
+        )
+
+    async def search(
+        self,
+        query: str,
+        vaults: Iterable[str] | None = None,
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+        provider=None,
+        timeout: Optional[float] = None,
+    ) -> List[ResearchResult]:
+        return await _search(
+            query,
+            vaults,
+            k_per_vault=k_per_vault,
+            rrf_k=rrf_k,
+            chroma_path=chroma_path,
+            vault=vault,
+            provider=provider,
+            timeout=timeout,
+        )
+
+    def search_sync(
+        self,
+        query: str,
+        vaults: Iterable[str] | None = None,
+        *,
+        k_per_vault: int = 5,
+        rrf_k: int = 60,
+        chroma_path: Optional[str] = None,
+        vault: Optional[str] = None,
+        provider=None,
+        timeout: Optional[float] = None,
+    ) -> List[ResearchResult]:
+        return _search_sync(
+            query,
+            vaults,
+            k_per_vault=k_per_vault,
+            rrf_k=rrf_k,
+            chroma_path=chroma_path,
+            vault=vault,
+            provider=provider,
+            timeout=timeout,
+        )
+
+
+search = _search
+search_async = _search_async
+search_sync = _search_sync
+adapter = CascadenceAdapter()


### PR DESCRIPTION
## Summary
- add a lightweight TaskCascadence adapter module re-exporting the search entrypoints without the CLI stack
- document the minimal interface and optional cascandence extra in the README
- register packaging metadata to advertise the integration via entry points

## Testing
- python -m pytest
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692478d8fef48326b6ff7448d494718e)