### PR TITLE
Handle provider failures with resilient search results

### DIFF
--- a/src/tino_storm/cascadence.py
+++ b/src/tino_storm/cascadence.py
@@ -37,6 +37,7 @@ class CascadenceAdapter:
         vault: Optional[str] = None,
         provider=None,
         timeout: Optional[float] = None,
+        raise_on_error: bool = False,
     ):
         try:
             asyncio.get_running_loop()
@@ -50,6 +51,7 @@ class CascadenceAdapter:
                 vault=vault,
                 provider=provider,
                 timeout=timeout,
+                raise_on_error=raise_on_error,
             )
         return _search(
             query,
@@ -60,6 +62,7 @@ class CascadenceAdapter:
             vault=vault,
             provider=provider,
             timeout=timeout,
+            raise_on_error=raise_on_error,
         )
 
     async def search(
@@ -73,6 +76,7 @@ class CascadenceAdapter:
         vault: Optional[str] = None,
         provider=None,
         timeout: Optional[float] = None,
+        raise_on_error: bool = False,
     ) -> List[ResearchResult]:
         return await _search(
             query,
@@ -83,6 +87,7 @@ class CascadenceAdapter:
             vault=vault,
             provider=provider,
             timeout=timeout,
+            raise_on_error=raise_on_error,
         )
 
     def search_sync(
@@ -96,6 +101,7 @@ class CascadenceAdapter:
         vault: Optional[str] = None,
         provider=None,
         timeout: Optional[float] = None,
+        raise_on_error: bool = False,
     ) -> List[ResearchResult]:
         return _search_sync(
             query,
@@ -106,6 +112,7 @@ class CascadenceAdapter:
             vault=vault,
             provider=provider,
             timeout=timeout,
+            raise_on_error=raise_on_error,
         )
 
 

--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 import threading
-from typing import Callable, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from .providers import (
     DefaultProvider,
@@ -42,6 +42,33 @@ class ResearchError(RuntimeError):
     def __init__(self, message: str, *, provider_spec: str | None = None) -> None:
         super().__init__(message)
         self.provider_spec = provider_spec
+
+
+class SearchResults(List[ResearchResult]):
+    """List-like container that also records structured error metadata."""
+
+    def __init__(self, iterable=None, *, errors: Optional[List[Dict[str, Any]]] = None):
+        super().__init__(iterable or [])
+        self.errors: List[Dict[str, Any]] = errors or []
+
+
+def _provider_name(provider: Provider | str | None) -> Optional[str]:
+    if isinstance(provider, str):
+        return provider
+    if provider is None:
+        return None
+    return getattr(provider, "name", None) or provider.__class__.__name__
+
+
+def _error_metadata(
+    query: str, error: Exception, provider: Provider | str | None
+) -> Dict[str, Any]:
+    return {
+        "error": str(error),
+        "provider": _provider_name(provider) or getattr(error, "provider_spec", None),
+        "exception_type": error.__class__.__name__,
+        "query": query,
+    }
 
 
 def _resolve_provider(provider: Provider | str | None) -> Provider:
@@ -128,15 +155,31 @@ async def search_async(
     vault: Optional[str] = None,
     provider: Provider | str | None = None,
     timeout: Optional[float] = None,
+    raise_on_error: bool = False,
 ) -> List[ResearchResult]:
     """Asynchronously query ``vaults`` using the configured provider."""
 
     if vaults is None:
         vaults = list_vaults()
 
-    provider = _resolve_provider(provider)
     try:
-        return await provider.search_async(
+        provider = _resolve_provider(provider)
+    except Exception as e:
+        logging.error(f"Search failed for query {query}: {e}")
+        await event_emitter.emit(
+            ResearchAdded(topic=query, information_table={"error": str(e)})
+        )
+        if raise_on_error:
+            if isinstance(e, ResearchError):
+                raise
+            raise ResearchError(str(e)) from e
+        return SearchResults(
+            [],
+            errors=[_error_metadata(query, e, provider)],
+        )
+
+    try:
+        results = await provider.search_async(
             query,
             vaults,
             k_per_vault=k_per_vault,
@@ -145,12 +188,20 @@ async def search_async(
             vault=vault,
             timeout=timeout,
         )
+        if isinstance(results, SearchResults):
+            return results
+        return SearchResults(results)
     except Exception as e:
         logging.error(f"Search failed for query {query}: {e}")
         await event_emitter.emit(
             ResearchAdded(topic=query, information_table={"error": str(e)})
         )
-        raise ResearchError(str(e)) from e
+        if raise_on_error:
+            raise ResearchError(str(e)) from e
+        return SearchResults(
+            [],
+            errors=[_error_metadata(query, e, provider)],
+        )
 
 
 def search_sync(
@@ -163,16 +214,31 @@ def search_sync(
     vault: Optional[str] = None,
     provider: Provider | str | None = None,
     timeout: Optional[float] = None,
+    raise_on_error: bool = False,
 ) -> List[ResearchResult]:
     """Synchronously query ``vaults`` using the configured provider."""
 
     if vaults is None:
         vaults = list_vaults()
 
-    provider = _resolve_provider(provider)
+    try:
+        provider = _resolve_provider(provider)
+    except Exception as e:
+        logging.error(f"Search failed for query {query}: {e}")
+        event_emitter.emit_sync(
+            ResearchAdded(topic=query, information_table={"error": str(e)})
+        )
+        if raise_on_error:
+            if isinstance(e, ResearchError):
+                raise
+            raise ResearchError(str(e)) from e
+        return SearchResults(
+            [],
+            errors=[_error_metadata(query, e, provider)],
+        )
 
     try:
-        return provider.search_sync(
+        results = provider.search_sync(
             query,
             vaults,
             k_per_vault=k_per_vault,
@@ -181,12 +247,15 @@ def search_sync(
             vault=vault,
             timeout=timeout,
         )
+        if isinstance(results, SearchResults):
+            return results
+        return SearchResults(results)
     except NotImplementedError:
         try:
             asyncio.get_running_loop()
         except RuntimeError:
             try:
-                return asyncio.run(
+                results = asyncio.run(
                     provider.search_async(
                         query,
                         vaults,
@@ -197,12 +266,20 @@ def search_sync(
                         timeout=timeout,
                     )
                 )
+                if isinstance(results, SearchResults):
+                    return results
+                return SearchResults(results)
             except Exception as e:  # pragma: no cover - defensive fallback
                 logging.error(f"Search failed for query {query}: {e}")
                 event_emitter.emit_sync(
                     ResearchAdded(topic=query, information_table={"error": str(e)})
                 )
-                raise ResearchError(str(e)) from e
+                if raise_on_error:
+                    raise ResearchError(str(e)) from e
+                return SearchResults(
+                    [],
+                    errors=[_error_metadata(query, e, provider)],
+                )
         raise RuntimeError(
             "search_sync cannot run inside a running event loop when the provider "
             "only implements asynchronous search; use search_async instead."
@@ -212,7 +289,12 @@ def search_sync(
         event_emitter.emit_sync(
             ResearchAdded(topic=query, information_table={"error": str(e)})
         )
-        raise ResearchError(str(e)) from e
+        if raise_on_error:
+            raise ResearchError(str(e)) from e
+        return SearchResults(
+            [],
+            errors=[_error_metadata(query, e, provider)],
+        )
 
 
 async def search(
@@ -225,6 +307,7 @@ async def search(
     vault: Optional[str] = None,
     provider: Provider | str | None = None,
     timeout: Optional[float] = None,
+    raise_on_error: bool = False,
 ) -> List[ResearchResult]:
     """Asynchronously query ``vaults`` via :func:`search_async`."""
 
@@ -237,4 +320,5 @@ async def search(
         vault=vault,
         provider=provider,
         timeout=timeout,
+        raise_on_error=raise_on_error,
     )

--- a/tests/test_provider_errors.py
+++ b/tests/test_provider_errors.py
@@ -1,6 +1,6 @@
 import pytest
 from tino_storm.events import event_emitter, ResearchAdded
-from tino_storm.search import ResearchError, search_sync
+from tino_storm.search import ResearchError, SearchResults, search_sync
 
 
 def test_bing_error_emits_event(monkeypatch):
@@ -87,9 +87,15 @@ def test_search_provider_exception_emits_event(monkeypatch):
         def search_sync(self, *a, **k):
             raise RuntimeError("boom")
 
-    with pytest.raises(ResearchError):
-        search_sync("topic", [], provider=StubProvider())
+    results = search_sync("topic", [], provider=StubProvider())
 
+    assert isinstance(results, SearchResults)
+    assert results == []
+    assert len(results.errors) == 1
+    assert results.errors[0]["error"] == "boom"
     assert len(events) == 1
     assert events[0].topic == "topic"
     assert events[0].information_table["error"] == "boom"
+
+    with pytest.raises(ResearchError):
+        search_sync("topic", [], provider=StubProvider(), raise_on_error=True)

--- a/tests/test_search_provider_failure.py
+++ b/tests/test_search_provider_failure.py
@@ -2,7 +2,7 @@ import pytest
 
 import tino_storm
 from tino_storm.events import ResearchAdded, event_emitter
-from tino_storm.search import ResearchError, search_sync as search_func
+from tino_storm.search import ResearchError, SearchResults, search_sync as search_func
 
 
 def test_invalid_env_provider_emits_event(monkeypatch):
@@ -19,11 +19,38 @@ def test_invalid_env_provider_emits_event(monkeypatch):
 
     monkeypatch.setattr(tino_storm, "search_sync", search_func)
 
+    results = tino_storm.search_sync("topic", [])
+
+    assert isinstance(results, SearchResults)
+    assert results == []
+    assert len(results.errors) == 1
+    error_meta = results.errors[0]
+    assert error_meta["provider"] == spec
+    assert "error" in error_meta
+    assert len(events) == 2
+    spec_event, query_event = events
+    assert spec_event.topic == spec
+    assert query_event.topic == "topic"
+    assert spec_event.information_table["error"] == error_meta["error"]
+    assert query_event.information_table["error"] == error_meta["error"]
+
+
+def test_invalid_env_provider_can_raise(monkeypatch):
+    monkeypatch.setattr(event_emitter, "_subscribers", {})
+    events = []
+
+    def handler(e: ResearchAdded) -> None:
+        events.append(e)
+
+    event_emitter.subscribe(ResearchAdded, handler)
+
+    spec = "nonexistent.module.Provider"
+    monkeypatch.setenv("STORM_SEARCH_PROVIDER", spec)
+
+    monkeypatch.setattr(tino_storm, "search_sync", search_func)
+
     with pytest.raises(ResearchError) as exc:
-        tino_storm.search_sync("topic", [])
+        tino_storm.search_sync("topic", [], raise_on_error=True)
 
     assert exc.value.provider_spec == spec
-    assert len(events) == 1
-    event = events[0]
-    assert event.topic == spec
-    assert event.information_table["error"] == str(exc.value)
+    assert len(events) == 2

--- a/tests/test_search_vaults_timeout.py
+++ b/tests/test_search_vaults_timeout.py
@@ -32,5 +32,20 @@ def test_search_vaults_timeout(monkeypatch):
         "tino_storm.ingest.search.get_passphrase", lambda vault=None: None
     )
 
+    results = search_sync("q", ["v1"], timeout=0.05)
+
+    assert results == []
+    assert hasattr(results, "errors")
+    assert results.errors[0]["exception_type"] == "TimeoutError"
+
+
+def test_search_vaults_timeout_can_raise(monkeypatch):
+    coll = SlowCollection()
+    client = DummyClient(coll)
+    monkeypatch.setattr("chromadb.PersistentClient", lambda *a, **k: client)
+    monkeypatch.setattr(
+        "tino_storm.ingest.search.get_passphrase", lambda vault=None: None
+    )
+
     with pytest.raises(ResearchError):
-        search_sync("q", ["v1"], timeout=0.05)
+        search_sync("q", ["v1"], timeout=0.05, raise_on_error=True)


### PR DESCRIPTION
## Summary
- add a SearchResults container that carries structured error metadata and a raise_on_error toggle for search helpers
- propagate the resilience flag through the Cascadence adapter so TaskCascadence defaults to non-raising behavior while opt-in raising remains available
- update provider failure and timeout tests to cover fallback responses, logged events, and the raise_on_error pathway

## Testing
- python -m pytest tests/test_search_provider_failure.py tests/test_provider_errors.py tests/test_search_vaults_timeout.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938296bf4548326b1b46473da307d83)