### PR TITLE
Add research-core extra and guard vector store optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,6 @@ dependencies = [
     "numpy==1.26.4",
     "pytz",
     "httpx>=0.27.0,<0.29",
-    "chromadb",
-
     "requests>=2.31.0",
     "PyYAML>=6.0",
     "cryptography>=41.0.0",
@@ -51,6 +49,7 @@ research = [
     "uvicorn>=0.29.0",
     "watchdog",
     "knowledge-storm",
+    "chromadb",
 ]
 cascadence = []
 retrieval = [
@@ -59,6 +58,19 @@ retrieval = [
     "langchain-huggingface",
     "qdrant-client",
     "langchain-qdrant",
+]
+research-core = [
+    "toml",
+    "trafilatura",
+    "numpy==1.26.4",
+    "pytz",
+    "httpx>=0.27.0,<0.29",
+    "requests>=2.31.0",
+    "PyYAML>=6.0",
+    "cryptography>=41.0.0",
+]
+vector-store = [
+    "chromadb",
 ]
 
 [build-system]

--- a/src/tino_storm/_extras.py
+++ b/src/tino_storm/_extras.py
@@ -66,7 +66,10 @@ def ensure_optional_dependency_stub(module: str, extra: str) -> None:
     if module in sys.modules:
         return
 
-    spec = importlib.util.find_spec(module)
+    try:
+        spec = importlib.util.find_spec(module)
+    except ModuleNotFoundError:
+        spec = None
     if spec is not None:  # The real module is available; do nothing.
         return
 

--- a/src/tino_storm/ingest/__init__.py
+++ b/src/tino_storm/ingest/__init__.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Optional
 
+from .._extras import MissingExtraError
 from .search import search_vaults
 
 WATCHDOG_INSTALL_HINT = (
@@ -21,12 +22,13 @@ class _WatchdogProxy:
         "__tino_missing_dependency_message__",
     )
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, message: str = WATCHDOG_INSTALL_HINT) -> None:
         self._name = name
         self.__name__ = name
         self.__qualname__ = name
-        self.__tino_missing_dependency__ = "watchdog"
-        self.__tino_missing_dependency_message__ = WATCHDOG_INSTALL_HINT
+        dependency = "vector-store" if "vector-store" in message else "watchdog"
+        self.__tino_missing_dependency__ = dependency
+        self.__tino_missing_dependency_message__ = message
 
     def _raise(self) -> None:
         raise ImportError(self.__tino_missing_dependency_message__)
@@ -43,12 +45,13 @@ class _WatchdogProxy:
 
 try:
     from .watcher import start_watcher, VaultIngestHandler, load_txt_documents
-except ImportError as exc:  # pragma: no cover - optional dependency
-    if "watchdog is required" not in str(exc):
+except (ImportError, MissingExtraError) as exc:  # pragma: no cover - optional dependency
+    message = str(exc)
+    if "watchdog is required" not in message and "vector-store" not in message:
         raise
-    start_watcher = _WatchdogProxy("start_watcher")
-    VaultIngestHandler = _WatchdogProxy("VaultIngestHandler")
-    load_txt_documents = _WatchdogProxy("load_txt_documents")
+    start_watcher = _WatchdogProxy("start_watcher", message)
+    VaultIngestHandler = _WatchdogProxy("VaultIngestHandler", message)
+    load_txt_documents = _WatchdogProxy("load_txt_documents", message)
 
 
 def ingest_path(

--- a/src/tino_storm/ingest/search.py
+++ b/src/tino_storm/ingest/search.py
@@ -7,8 +7,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
-import chromadb
-
+from .._extras import MissingExtraError, require_extra
 from .utils import list_vaults  # noqa: F401
 from ..events import ResearchAdded, event_emitter
 from ..security import (
@@ -36,6 +35,18 @@ def search_vaults(
 ) -> List[Dict[str, Any]]:
     """Query multiple Chroma namespaces and combine results using RRF."""
 
+    vault_list = list(vaults)
+    if not vault_list:
+        return []
+
+    try:
+        chromadb = require_extra("chromadb", "vector-store")
+    except MissingExtraError:
+        logging.warning(
+            "chromadb is missing; install the 'vector-store' extra for vault search"
+        )
+        return []
+
     chroma_root = Path(
         chroma_path
         or os.environ.get("STORM_CHROMA_PATH", Path.home() / ".tino_storm" / "chroma")
@@ -57,7 +68,7 @@ def search_vaults(
         client_map: dict[str | None, Any] = {}
 
     rankings: List[List[Dict[str, Any]]] = []
-    for vault_name in vaults:
+    for vault_name in vault_list:
         if vault is not None:
             collection = client.get_or_create_collection(vault_name)
         else:

--- a/src/tino_storm/ingest/watcher.py
+++ b/src/tino_storm/ingest/watcher.py
@@ -8,6 +8,8 @@ import asyncio
 from pathlib import Path
 from typing import Any, Optional, List
 
+from .._extras import require_extra
+
 try:
     from watchdog.events import FileSystemEventHandler
     from watchdog.observers import Observer
@@ -16,7 +18,6 @@ except ImportError as e:  # pragma: no cover - optional dependency
         "watchdog is required for ingestion features; install with 'tino-storm[research]'"
     ) from e
 
-import chromadb
 import trafilatura
 from weakref import ref, ReferenceType
 
@@ -159,6 +160,7 @@ class VaultIngestHandler(FileSystemEventHandler):
                 atexit.register(encrypt_parquet_files, self._chroma_root, passphrase)
             client = EncryptedChroma(self._chroma_root, passphrase=passphrase)
         else:
+            chromadb = require_extra("chromadb", "vector-store")
             client = chromadb.PersistentClient(path=self._chroma_root)
         self._instrument_client(client)
         return client

--- a/src/tino_storm/providers/base.py
+++ b/src/tino_storm/providers/base.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 from contextlib import suppress
 from typing import Any, Awaitable, Dict, Iterable, List, Optional, TypeVar
 
+from .._extras import MissingExtraError
 from ..search_result import ResearchResult, as_research_result
 
 from ..ingest import search_vaults
@@ -281,15 +282,18 @@ class DefaultProvider(Provider):
         vault: Optional[str] = None,
         timeout: Optional[float] = None,
     ) -> List[ResearchResult]:
-        raw_results = search_vaults(
-            query,
-            vaults,
-            k_per_vault=k_per_vault,
-            rrf_k=rrf_k,
-            chroma_path=chroma_path,
-            vault=vault,
-            timeout=timeout,
-        )
+        try:
+            raw_results = search_vaults(
+                query,
+                vaults,
+                k_per_vault=k_per_vault,
+                rrf_k=rrf_k,
+                chroma_path=chroma_path,
+                vault=vault,
+                timeout=timeout,
+            )
+        except MissingExtraError:
+            raw_results = []
         if raw_results:
             results = [as_research_result(r) for r in raw_results]
             _ensure_source(results, "vault")
@@ -324,16 +328,19 @@ class DefaultProvider(Provider):
         vault: Optional[str] = None,
         timeout: Optional[float] = None,
     ) -> List[ResearchResult]:
-        raw_results = await asyncio.to_thread(
-            search_vaults,
-            query,
-            vaults,
-            k_per_vault=k_per_vault,
-            rrf_k=rrf_k,
-            chroma_path=chroma_path,
-            vault=vault,
-            timeout=timeout,
-        )
+        try:
+            raw_results = await asyncio.to_thread(
+                search_vaults,
+                query,
+                vaults,
+                k_per_vault=k_per_vault,
+                rrf_k=rrf_k,
+                chroma_path=chroma_path,
+                vault=vault,
+                timeout=timeout,
+            )
+        except MissingExtraError:
+            raw_results = []
         if raw_results:
             results = [as_research_result(r) for r in raw_results]
             _ensure_source(results, "vault")

--- a/src/tino_storm/security/encrypted_chroma.py
+++ b/src/tino_storm/security/encrypted_chroma.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import base64
 from typing import Any, List, Optional
 
-import chromadb
-from chromadb.api import Collection
-from chromadb.config import Settings
+from typing import TYPE_CHECKING
+
+from .._extras import require_extra
+
+if TYPE_CHECKING:  # pragma: no cover
+    import chromadb
+    from chromadb.api import Collection
+    from chromadb.config import Settings
 
 from .config import get_passphrase
 from .crypto import encrypt_bytes, decrypt_bytes
@@ -16,7 +21,7 @@ from .crypto import encrypt_bytes, decrypt_bytes
 class EncryptedCollection:
     """A thin wrapper over a Chroma ``Collection`` that encrypts documents."""
 
-    def __init__(self, collection: Collection, passphrase: Optional[str] = None):
+    def __init__(self, collection: "Collection", passphrase: Optional[str] = None):
         self._collection = collection
         self._passphrase = passphrase or get_passphrase()
 
@@ -61,6 +66,9 @@ class EncryptedChroma:
     """Helper that creates encrypted Chroma collections."""
 
     def __init__(self, path: str, passphrase: Optional[str] = None, **settings: Any):
+        chromadb = require_extra("chromadb", "vector-store")
+        Settings = chromadb.config.Settings
+
         self._passphrase = passphrase or get_passphrase()
         self._client = chromadb.PersistentClient(
             path=path, settings=Settings(**settings)

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,6 +1,9 @@
 import importlib
 import sys
 
+import importlib
+import sys
+
 import pytest
 
 from tino_storm._extras import MissingExtraError
@@ -66,3 +69,22 @@ def test_research_skill_missing_dspy(monkeypatch, _restore_module_cache):
         importlib.import_module("tino_storm.skills.research")
 
     assert "pip install tino-storm[llm]" in str(excinfo.value)
+
+
+def test_research_core_callable_without_vector_store(monkeypatch, _restore_module_cache):
+    _simulate_missing(monkeypatch, "chromadb")
+
+    class DummyProvider:
+        def search_sync(self, *args, **kwargs):
+            from tino_storm.search_result import ResearchResult
+
+            return [ResearchResult(url="http://example.com", snippets=["test"])]
+
+        async def search_async(self, *args, **kwargs):  # pragma: no cover - sync path
+            return self.search_sync(*args, **kwargs)
+
+    from tino_storm import search_sync
+
+    results = search_sync("query", provider=DummyProvider())
+
+    assert results


### PR DESCRIPTION
## Summary
- add a minimal research-core extra and make vector store dependencies optional
- guard chromadb usage with dependency checks and stubs to allow lightweight imports
- expand optional dependency tests to cover the slim research callable path

## Testing
- pytest tests/test_optional_dependencies.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693982b086948326adb7b4e799c94d9e)