### PR TITLE
Prefer registry lookup for STORM_SEARCH_PROVIDER single values

### DIFF
--- a/src/tino_storm/search.py
+++ b/src/tino_storm/search.py
@@ -93,7 +93,13 @@ def _resolve_provider(provider: Provider | str | None) -> Provider:
 
                     return _get_or_create_provider(spec, factory)
 
-                return _get_or_create_provider(spec, lambda: load_provider(spec))
+                def factory() -> Provider:
+                    try:
+                        return provider_registry.get(spec)
+                    except KeyError:
+                        return load_provider(spec)
+
+                return _get_or_create_provider(spec, factory)
             except Exception as e:
                 logging.exception("Failed to load provider '%s'", spec)
                 _emit_load_error(spec, e)

--- a/tests/test_provider_loading.py
+++ b/tests/test_provider_loading.py
@@ -115,6 +115,43 @@ def test_search_uses_env_provider(monkeypatch):
     assert calls["args"] == ("q", ["v"], 5, 60, None, None, None)
 
 
+def test_resolve_provider_uses_env_dotted_path(monkeypatch):
+    class DummyProvider(Provider):
+        def search_sync(self, *a, **k):
+            return []
+
+    mod = types.ModuleType("dummy_env_provider_mod")
+    mod.DummyProvider = DummyProvider
+    monkeypatch.setitem(sys.modules, "dummy_env_provider_mod", mod)
+    monkeypatch.setenv("STORM_SEARCH_PROVIDER", "dummy_env_provider_mod.DummyProvider")
+    _PROVIDER_CACHE.clear()
+
+    provider = _resolve_provider(None)
+
+    assert isinstance(provider, DummyProvider)
+
+
+def test_resolve_provider_emits_event_on_invalid_env_spec(monkeypatch):
+    events: list[ResearchAdded] = []
+
+    def handler(event: ResearchAdded) -> None:
+        events.append(event)
+
+    _PROVIDER_CACHE.clear()
+    monkeypatch.setenv("STORM_SEARCH_PROVIDER", "bad provider spec")
+    event_emitter.subscribe(ResearchAdded, handler)
+    try:
+        with pytest.raises(ResearchError) as exc:
+            _resolve_provider(None)
+    finally:
+        event_emitter.unsubscribe(ResearchAdded, handler)
+
+    assert len(events) == 1
+    assert events[0].topic == "bad provider spec"
+    assert "error" in events[0].information_table
+    assert exc.value.provider_spec == "bad provider spec"
+
+
 def test_parallel_provider_gathers_and_merges(monkeypatch):
     gathered = {}
 

--- a/tests/test_search_provider_cache.py
+++ b/tests/test_search_provider_cache.py
@@ -49,3 +49,12 @@ def test_env_provider_list_builds_aggregator(monkeypatch, env_value):
 
     monkeypatch.delenv("STORM_SEARCH_PROVIDER")
 
+
+def test_env_provider_registered_name_resolves(monkeypatch):
+    _clear_provider_cache()
+    monkeypatch.setenv("STORM_SEARCH_PROVIDER", "parallel")
+
+    provider = search_module._resolve_provider(None)
+
+    assert provider is search_module.provider_registry.get("parallel")
+    assert search_module._resolve_provider(None) is provider


### PR DESCRIPTION
### Motivation
- When `STORM_SEARCH_PROVIDER` is a single (non-comma) value, prefer resolving a registered provider name from `provider_registry` before attempting dotted-path loading, to make env-based configuration more intuitive. 
- Keep the existing dotted-path fallback and the existing error emission / `ResearchError(provider_spec=...)` semantics intact for malformed specs.

### Description
- Update `src/tino_storm/search.py::_resolve_provider` so that in the `provider is None` branch with a single `STORM_SEARCH_PROVIDER` value it first calls `provider_registry.get(spec)` and falls back to `load_provider(spec)` on `KeyError`. 
- Implement the lookup inside the same provider caching path by providing a `factory` that tries the registry then the dotted-path loader. 
- Add `test_env_provider_registered_name_resolves` to `tests/test_search_provider_cache.py` to verify a registered name like `"parallel"` resolves and is cached. 
- Add `test_resolve_provider_uses_env_dotted_path` and `test_resolve_provider_emits_event_on_invalid_env_spec` to `tests/test_provider_loading.py` to cover dotted-path env values and malformed env values that should emit an event and raise `ResearchError` with `provider_spec`.

### Testing
- Ran `pytest -q tests/test_search_provider_cache.py tests/test_provider_loading.py` and all tests passed (`13 passed`).
- Ran linter with `ruff check src/tino_storm/search.py tests/test_search_provider_cache.py tests/test_provider_loading.py` and checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e6c4d9248326bd11c7822dd93adb)