### PR TITLE
Enforce soft-fail search contract: docs, API, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,26 @@ Third-party packages may expose providers through the
 After installation the provider can be used by name with
 `tino_storm.search()` or retrieved from `provider_registry`.
 
+
+#### Error handling contract
+
+`tino_storm.search_sync()` and `tino_storm.search_async()` soft-fail by default.
+On provider failures they return `SearchResults` with an empty result list and
+structured diagnostics in `results.errors`. Set `raise_on_error=True` to opt
+into raising `ResearchError` instead.
+
+```python
+from tino_storm.search import ResearchError, search_sync
+
+results = search_sync("cats", ["science"], provider="my-provider")
+print(results.errors)
+
+try:
+    search_sync("cats", ["science"], provider="my-provider", raise_on_error=True)
+except ResearchError as exc:
+    print("Search failed:", exc)
+```
+
 ### HTTP API
 
 When running `tino-storm serve` the following POST endpoints become available:
@@ -250,8 +270,10 @@ When running `tino-storm serve` the following POST endpoints become available:
 The first three endpoints accept a JSON body with `topic`, optional
 `output_dir` and `vault` fields.  The `/ingest` endpoint expects `text`,
 `vault` and an optional `source` identifying the origin of the text.  The
-`/search` endpoint expects `query`, a list of `vaults` and optional
-`k_per_vault` and `rrf_k` parameters.
+`/search` endpoint expects `query`, a list of `vaults`, optional
+`k_per_vault` and `rrf_k` parameters, and optional `raise_on_error`
+(default `false`). Successful responses include both `results` and `errors`,
+where `errors` mirrors `SearchResults.errors`.
 
 If the research workflow cannot start, the `/research`, `/outline` and
 `/draft` endpoints return a JSON error payload in the following format:

--- a/docs/research_plugin.md
+++ b/docs/research_plugin.md
@@ -75,8 +75,10 @@ invoked.
 ### Misconfigured providers
 
 If a provider specified via `STORM_SEARCH_PROVIDER` fails to load or lacks
-required settings, `tino_storm.search()` raises `ResearchError`. Wrap calls in a
-`try`/`except` block to handle these errors gracefully.
+required settings, `tino_storm.search()` and `tino_storm.search_async()`
+soft-fail by default and return an empty `SearchResults` object with structured
+error metadata in `results.errors`. Pass `raise_on_error=True` to opt into
+raising `ResearchError`.
 
 ```python
 import os
@@ -84,8 +86,12 @@ import tino_storm
 from tino_storm.search import ResearchError
 
 os.environ["STORM_SEARCH_PROVIDER"] = "my_package.providers.MisconfiguredProvider"
+
+results = tino_storm.search_sync("large language models")
+print(results.errors)
+
 try:
-    tino_storm.search("large language models")
+    tino_storm.search_sync("large language models", raise_on_error=True)
 except ResearchError as exc:
     print("Provider misconfigured:", exc)
 ```
@@ -177,14 +183,19 @@ export STORM_SEARCH_PROVIDER="docs_hub, parallel"
 
 ## Error handling
 
-When a provider fails to complete a query, ``search`` and ``search_async``
-raise ``ResearchError``. Catch this exception to handle failures gracefully.
+When a provider fails to complete a query, ``search_sync`` and ``search_async``
+return a ``SearchResults`` list with ``errors`` populated by default. Each error
+entry includes the failing provider name, exception type, query, and message.
+Set ``raise_on_error=True`` to raise ``ResearchError`` instead.
 
 ```python
-from tino_storm.search import ResearchError, search
+from tino_storm.search import ResearchError, search_sync
+
+results = search_sync("large language models", provider="failing-provider")
+print(results.errors)
 
 try:
-    search("large language models", provider="failing-provider")
+    search_sync("large language models", provider="failing-provider", raise_on_error=True)
 except ResearchError as e:
     print("Search failed:", e)
 ```

--- a/src/tino_storm/api.py
+++ b/src/tino_storm/api.py
@@ -7,6 +7,7 @@ from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from . import search
+from .search import ResearchError, SearchResults
 from .events import ResearchAdded, event_emitter
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
@@ -130,13 +131,23 @@ def _register_routes(app: Any, models: _RequestModels) -> None:
     @app.post("/search")
     async def search_endpoint(req: SearchRequestModel) -> Dict[str, Any]:
         data = _model_to_dict(req)
-        result = await search(
-            data["query"],
-            data["vaults"],
-            k_per_vault=data.get("k_per_vault", 5),
-            rrf_k=data.get("rrf_k", 60),
-        )
-        return {"results": [asdict(r) for r in result]}
+        try:
+            result = await search(
+                data["query"],
+                data["vaults"],
+                k_per_vault=data.get("k_per_vault", 5),
+                rrf_k=data.get("rrf_k", 60),
+                raise_on_error=data.get("raise_on_error", False),
+            )
+        except ResearchError as exc:
+            detail = {"error": str(exc)}
+            http_exc = _maybe_raise_http_error(detail)
+            if http_exc is not None:
+                raise http_exc
+            return {"status": "error", "detail": detail}
+
+        errors = result.errors if isinstance(result, SearchResults) else []
+        return {"results": [asdict(r) for r in result], "errors": errors}
 
 
 def _create_fastapi_app():
@@ -163,6 +174,7 @@ def _create_fastapi_app():
         vaults: List[str]
         k_per_vault: int = 5
         rrf_k: int = 60
+        raise_on_error: bool = False
 
     fastapi_app = FastAPI(title="tino-storm API")
     _register_routes(

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -91,6 +91,7 @@ class AsyncClient:
         elif path == "/search":
             data.setdefault("k_per_vault", 5)
             data.setdefault("rrf_k", 60)
+            data.setdefault("raise_on_error", False)
         arg = types.SimpleNamespace(**data)
         result = fn(arg)
         if asyncio.iscoroutine(result):
@@ -216,8 +217,8 @@ def test_ingest_endpoint(monkeypatch):
 def test_search_endpoint(monkeypatch):
     called = {}
 
-    async def fake_search(query, vaults, *, k_per_vault=5, rrf_k=60):
-        called["args"] = (query, list(vaults), k_per_vault, rrf_k)
+    async def fake_search(query, vaults, *, k_per_vault=5, rrf_k=60, raise_on_error=False):
+        called["args"] = (query, list(vaults), k_per_vault, rrf_k, raise_on_error)
         return [ResearchResult(url="u", snippets=["s"], meta={})]
 
     monkeypatch.setattr(api_module, "search", fake_search)
@@ -235,7 +236,7 @@ def test_search_endpoint(monkeypatch):
         "score": None,
         "posterior": None,
     }
-    assert called["args"] == ("q", ["v1", "v2"], 5, 60)
+    assert called["args"] == ("q", ["v1", "v2"], 5, 60, False)
 
 
 def test_ingestion_failure_emits_event(monkeypatch, tmp_path, caplog):
@@ -526,8 +527,8 @@ def test_search_endpoint_asyncio(monkeypatch):
 
     called = {}
 
-    async def fake_search(query, vaults, *, k_per_vault=5, rrf_k=60):
-        called["args"] = (query, list(vaults), k_per_vault, rrf_k)
+    async def fake_search(query, vaults, *, k_per_vault=5, rrf_k=60, raise_on_error=False):
+        called["args"] = (query, list(vaults), k_per_vault, rrf_k, raise_on_error)
         return [ResearchResult(url="u", snippets=["s"], meta={})]
 
     monkeypatch.setattr(api_module, "search", fake_search)
@@ -553,8 +554,41 @@ def test_search_endpoint_asyncio(monkeypatch):
         "score": None,
         "posterior": None,
     }
-    assert called["args"] == ("q", ["v1", "v2"], 5, 60)
+    assert called["args"] == ("q", ["v1", "v2"], 5, 60, False)
 
+
+
+
+def test_search_endpoint_includes_errors(monkeypatch):
+    async def fake_search(query, vaults, *, k_per_vault=5, rrf_k=60, raise_on_error=False):
+        from tino_storm.search import SearchResults
+
+        return SearchResults([], errors=[{"error": "boom", "query": query}])
+
+    monkeypatch.setattr(api_module, "search", fake_search)
+
+    resp = asyncio.run(_post("/search", {"query": "q", "vaults": ["v1"]}))
+    assert resp.status_code == 200
+    assert resp.json() == {"results": [], "errors": [{"error": "boom", "query": "q"}]}
+
+
+def test_search_endpoint_raise_on_error_returns_error_payload(monkeypatch):
+    from tino_storm.search import ResearchError
+
+    async def fake_search(query, vaults, *, k_per_vault=5, rrf_k=60, raise_on_error=False):
+        assert raise_on_error is True
+        raise ResearchError("boom")
+
+    monkeypatch.setattr(api_module, "search", fake_search)
+
+    resp = asyncio.run(
+        _post(
+            "/search",
+            {"query": "q", "vaults": ["v1"], "raise_on_error": True},
+        )
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "error", "detail": {"error": "boom"}}
 
 def test_create_fastapi_app_missing_dependency(monkeypatch):
     stub_fastapi = types.ModuleType("fastapi")

--- a/tests/test_search_error_contract.py
+++ b/tests/test_search_error_contract.py
@@ -1,0 +1,65 @@
+import asyncio
+
+import pytest
+
+from tino_storm.search import ResearchError, SearchResults, search_async, search_sync
+
+
+class _FailingProvider:
+    def search_sync(self, query, vaults, **kwargs):
+        raise RuntimeError("boom")
+
+    async def search_async(self, query, vaults, **kwargs):
+        raise RuntimeError("boom")
+
+
+def test_search_sync_default_soft_fail_contract():
+    results = search_sync("topic", ["vault"], provider=_FailingProvider())
+
+    assert isinstance(results, SearchResults)
+    assert results == []
+    assert len(results.errors) == 1
+    error = results.errors[0]
+    assert error["error"] == "boom"
+    assert error["provider"] == "_FailingProvider"
+    assert error["exception_type"] == "RuntimeError"
+    assert error["query"] == "topic"
+
+
+def test_search_sync_raise_on_error_contract():
+    with pytest.raises(ResearchError, match="boom"):
+        search_sync(
+            "topic",
+            ["vault"],
+            provider=_FailingProvider(),
+            raise_on_error=True,
+        )
+
+
+def test_search_async_default_soft_fail_contract():
+    async def _run():
+        return await search_async("topic", ["vault"], provider=_FailingProvider())
+
+    results = asyncio.run(_run())
+
+    assert isinstance(results, SearchResults)
+    assert results == []
+    assert len(results.errors) == 1
+    error = results.errors[0]
+    assert error["error"] == "boom"
+    assert error["provider"] == "_FailingProvider"
+    assert error["exception_type"] == "RuntimeError"
+    assert error["query"] == "topic"
+
+
+def test_search_async_raise_on_error_contract():
+    async def _run():
+        return await search_async(
+            "topic",
+            ["vault"],
+            provider=_FailingProvider(),
+            raise_on_error=True,
+        )
+
+    with pytest.raises(ResearchError, match="boom"):
+        asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Establish a single canonical contract for search error handling: soft-fail by default and opt into raising via `raise_on_error=True`.
- Make the HTTP API consistent with the programmatic API and surface structured diagnostics (`SearchResults.errors`) to callers.
- Provide automated coverage for the contract across both sync and async code paths so downstream integrations can rely on stable semantics.

### Description
- Documented the soft-fail-by-default contract and `SearchResults.errors` semantics in `README.md` and `docs/research_plugin.md`, and explained `raise_on_error` usage.
- Updated `src/tino_storm/api.py` to accept `raise_on_error` in the `/search` request model, pass it through to `search(...)`, return `errors` alongside `results` on success, and return a structured error payload when a `ResearchError` is raised.
- Added a dedicated contract test module `tests/test_search_error_contract.py` that validates both sync and async behavior for default (soft-fail) and `raise_on_error=True` (raise `ResearchError`).
- Adjusted `tests/test_api_endpoints.py` to exercise the new `/search` request/response contract and added endpoint-level assertions for `errors` and `raise_on_error` passthrough, plus a small cleanup in `src/tino_storm/search.py` to remove a duplicated `raise`.

### Testing
- Ran the contract and endpoint tests with `pytest -q tests/test_search_error_contract.py tests/test_api_endpoints.py tests/test_search_provider_failure.py tests/test_search_errors.py`, and all executed tests passed (`26 passed, 4 warnings`).
- Ran the linter with `ruff check src tests`, which surfaced pre-existing unrelated lint errors (duplicate imports/redefinitions in files outside these changes); these linter issues were not introduced by this PR.
- Added and committed the changes and created tests to ensure the contract remains enforced in future CI runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8eb2637a88326a634e156fe4261d7)