### PR TITLE
Lazy-load optional provider implementations in tino_storm.providers

### DIFF
--- a/src/tino_storm/providers/__init__.py
+++ b/src/tino_storm/providers/__init__.py
@@ -2,15 +2,36 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Dict, Optional
+from importlib import import_module
+from typing import Dict, Optional, TYPE_CHECKING
 
 from .base import Provider, DefaultProvider, load_provider
-from .parallel import ParallelProvider
 from .registry import ProviderRegistry, provider_registry, register_provider
-from .aggregator import ProviderAggregator
-from .docs_hub import DocsHubProvider
-from .multi_source import MultiSourceProvider
-from .vector_db import VectorDBProvider
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .aggregator import ProviderAggregator
+    from .docs_hub import DocsHubProvider
+    from .multi_source import MultiSourceProvider
+    from .parallel import ParallelProvider
+    from .vector_db import VectorDBProvider
+
+_LAZY_ATTRS = {
+    "ParallelProvider": ("tino_storm.providers.parallel", "ParallelProvider"),
+    "ProviderAggregator": ("tino_storm.providers.aggregator", "ProviderAggregator"),
+    "DocsHubProvider": ("tino_storm.providers.docs_hub", "DocsHubProvider"),
+    "MultiSourceProvider": ("tino_storm.providers.multi_source", "MultiSourceProvider"),
+    "VectorDBProvider": ("tino_storm.providers.vector_db", "VectorDBProvider"),
+}
+
+_LAZY_SUBMODULES = {
+    "aggregator",
+    "base",
+    "docs_hub",
+    "multi_source",
+    "parallel",
+    "registry",
+    "vector_db",
+}
 
 
 @dataclass(frozen=True)
@@ -21,6 +42,20 @@ class ProviderCapabilities:
     docs_hub_remote: bool
     vector_retriever: bool
     bing: bool
+
+
+def __getattr__(name: str):
+    if name in _LAZY_ATTRS:
+        module_name, attr = _LAZY_ATTRS[name]
+        module = import_module(module_name)
+        value = getattr(module, attr)
+        globals()[name] = value
+        return value
+    if name in _LAZY_SUBMODULES:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def provider_capabilities() -> ProviderCapabilities:

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,9 +1,6 @@
 import importlib
 import sys
 
-import importlib
-import sys
-
 import pytest
 
 from tino_storm._extras import MissingExtraError
@@ -88,3 +85,26 @@ def test_research_core_callable_without_vector_store(monkeypatch, _restore_modul
     results = search_sync("query", provider=DummyProvider())
 
     assert results
+
+
+def test_import_search_with_missing_optional_provider_dependencies(
+    monkeypatch, _restore_module_cache
+):
+    for prefix in ("chromadb", "qdrant_client", "llama_index"):
+        _simulate_missing(monkeypatch, prefix)
+
+    for name in [
+        "tino_storm.search",
+        "tino_storm.providers",
+        "tino_storm.providers.docs_hub",
+        "tino_storm.providers.multi_source",
+        "tino_storm.providers.vector_db",
+    ]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    module = importlib.import_module("tino_storm.search")
+
+    assert module.search_sync is not None
+    assert "tino_storm.providers.docs_hub" not in sys.modules
+    assert "tino_storm.providers.multi_source" not in sys.modules
+    assert "tino_storm.providers.vector_db" not in sys.modules

--- a/tests/test_provider_loading.py
+++ b/tests/test_provider_loading.py
@@ -249,3 +249,22 @@ def test_resolve_provider_caches_instance(monkeypatch):
         assert calls["count"] == 1
     finally:
         _PROVIDER_CACHE.clear()
+
+
+def test_import_search_does_not_eagerly_load_optional_provider_modules(monkeypatch):
+    for name in [
+        "tino_storm.search",
+        "tino_storm.providers",
+        "tino_storm.providers.docs_hub",
+        "tino_storm.providers.multi_source",
+        "tino_storm.providers.vector_db",
+    ]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    import importlib
+
+    importlib.import_module("tino_storm.search")
+
+    assert "tino_storm.providers.docs_hub" not in sys.modules
+    assert "tino_storm.providers.multi_source" not in sys.modules
+    assert "tino_storm.providers.vector_db" not in sys.modules


### PR DESCRIPTION
### Motivation
- Prevent importing heavy/optional provider modules during basic package import to avoid `ModuleNotFoundError` or slow startup in minimal environments.
- Preserve core provider API surface (`Provider`, `DefaultProvider`, registry primitives, and `load_provider`) for consumers and tests that only need the registry or base types.
- Add regression checks so `import tino_storm.search` succeeds without pulling in `docs_hub`, `multi_source`, or `vector_db` implementations or their optional deps.

### Description
- Replaced eager top-level imports of provider implementations with lazy attribute loading via `__getattr__` and an `_LAZY_ATTRS` mapping so classes like `ParallelProvider`, `DocsHubProvider`, `ProviderAggregator`, `MultiSourceProvider`, and `VectorDBProvider` are imported only when accessed.
- Added `_LAZY_SUBMODULES` handling to allow dotted access like `tino_storm.providers.parallel` and `tino_storm.providers.registry` to continue to work without importing implementation modules eagerly.
- Kept `from .base import Provider, DefaultProvider, load_provider` and `from .registry import ProviderRegistry, provider_registry, register_provider` available at import time and added `TYPE_CHECKING`-only imports for static type-checkers.
- Added tests validating import behavior: `tests/test_provider_loading.py::test_import_search_does_not_eagerly_load_optional_provider_modules` and `tests/test_optional_dependencies.py::test_import_search_with_missing_optional_provider_dependencies`.

### Testing
- Ran linter checks (`ruff`) on the modified files and they passed for the changes made to `src/tino_storm/providers/__init__.py` and the new tests.
- Executed provider-related and newly added tests with `pytest` (targeted suites including `tests/test_provider_loading.py` and `tests/test_optional_dependencies.py`) and the provider-focused test subset passed.
- A full test-suite run in this environment reproduced unrelated, preexisting failures (e.g. encrypted Chroma / watcher integration tests); these failures are not caused by the lazy-loading changes and the targeted provider tests introduced here passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3950cbf52c83268a641c8c2de2a545)