### PR TITLE
Lazy-load BingSearch and guard optional Bing/LLM dependencies

### DIFF
--- a/src/tino_storm/providers/base.py
+++ b/src/tino_storm/providers/base.py
@@ -10,11 +10,10 @@ from collections import OrderedDict
 from contextlib import suppress
 from typing import Any, Awaitable, Dict, Iterable, List, Optional, TypeVar
 
-from .._extras import MissingExtraError
+from .._extras import MissingExtraError, require_extra
 from ..search_result import ResearchResult, as_research_result
 
 from ..ingest import search_vaults
-from ..core.rm import BingSearch
 from ..events import ResearchAdded, event_emitter
 
 # Maximum number of in-flight or cached summary tasks.
@@ -76,6 +75,18 @@ def format_bing_items(items: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
             meta["title"] = item.get("title")
         formatted.append({"url": url, "snippets": snippets, "meta": meta})
     return formatted
+
+
+def _load_bing_search_class():
+    """Load BingSearch only when Bing web search is actually used."""
+
+    require_extra("backoff", "llm")
+    require_extra("dspy", "llm", package="dspy_ai")
+    require_extra("dsp", "llm")
+
+    from ..core.rm import BingSearch
+
+    return BingSearch
 
 
 def _ensure_source(results: Iterable[ResearchResult], source: str) -> None:
@@ -153,9 +164,17 @@ class DefaultProvider(Provider):
             api_key = os.environ.get("BING_SEARCH_API_KEY")
             if not api_key:
                 return []
-            self._bing = BingSearch(
-                bing_search_api_key=api_key, k=self.bing_k, **self.bing_kwargs
-            )
+            try:
+                BingSearch = _load_bing_search_class()
+                self._bing = BingSearch(
+                    bing_search_api_key=api_key, k=self.bing_k, **self.bing_kwargs
+                )
+            except MissingExtraError as e:
+                logging.error(f"Bing search dependencies are unavailable: {e}")
+                event_emitter.emit_sync(
+                    ResearchAdded(topic=query, information_table={"error": str(e)})
+                )
+                return []
         try:
             kwargs: Dict[str, Any] = {}
             if timeout is not None:

--- a/tests/test_bing_search_import.py
+++ b/tests/test_bing_search_import.py
@@ -1,5 +1,69 @@
-from knowledge_storm.rm import BingSearch
+import importlib
+import sys
+
+import pytest
 
 
-def test_bing_search_import_available():
-    assert BingSearch is not None
+@pytest.fixture
+def _restore_module_cache():
+    original_modules = sys.modules.copy()
+    yield
+    for name in list(sys.modules):
+        if name not in original_modules:
+            sys.modules.pop(name)
+
+
+def _simulate_missing(monkeypatch, prefix: str) -> None:
+    for name in list(sys.modules):
+        if name == prefix or name.startswith(prefix + "."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == prefix or name.startswith(prefix + "."):
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, package=None):
+        if name == prefix or name.startswith(prefix + "."):
+            raise ModuleNotFoundError(name=prefix)
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+
+def test_provider_base_import_does_not_import_bing_search():
+    module = importlib.import_module("tino_storm.providers.base")
+
+    assert module.DefaultProvider is not None
+    assert "tino_storm.core.rm" not in sys.modules
+
+
+def test_tino_search_imports_without_bing_llm_extras(
+    monkeypatch, _restore_module_cache
+):
+    for dependency in ("dspy", "backoff", "dsp"):
+        _simulate_missing(monkeypatch, dependency)
+
+    module = importlib.import_module("tino_storm.search")
+
+    assert module.search_sync is not None
+
+
+def test_default_provider_bing_falls_back_without_llm_extras(
+    monkeypatch, _restore_module_cache, caplog
+):
+    for dependency in ("dspy", "backoff", "dsp"):
+        _simulate_missing(monkeypatch, dependency)
+    monkeypatch.setenv("BING_SEARCH_API_KEY", "test-key")
+
+    from tino_storm.providers.base import DefaultProvider
+
+    results = DefaultProvider()._bing_search("query")
+
+    assert results == []
+    assert "Bing search dependencies are unavailable" in caplog.text

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,9 +1,6 @@
 import importlib
 import sys
 
-import importlib
-import sys
-
 import pytest
 
 from tino_storm._extras import MissingExtraError
@@ -71,7 +68,9 @@ def test_research_skill_missing_dspy(monkeypatch, _restore_module_cache):
     assert "pip install tino-storm[llm]" in str(excinfo.value)
 
 
-def test_research_core_callable_without_vector_store(monkeypatch, _restore_module_cache):
+def test_research_core_callable_without_vector_store(
+    monkeypatch, _restore_module_cache
+):
     _simulate_missing(monkeypatch, "chromadb")
 
     class DummyProvider:
@@ -88,3 +87,16 @@ def test_research_core_callable_without_vector_store(monkeypatch, _restore_modul
     results = search_sync("query", provider=DummyProvider())
 
     assert results
+
+
+def test_search_import_without_llm_extras(monkeypatch, _restore_module_cache):
+    for dependency in ("dspy", "backoff", "dsp"):
+        _simulate_missing(monkeypatch, dependency)
+    monkeypatch.delitem(sys.modules, "tino_storm.search", raising=False)
+    monkeypatch.delitem(sys.modules, "tino_storm.providers.base", raising=False)
+    monkeypatch.delitem(sys.modules, "tino_storm.core.rm", raising=False)
+
+    module = importlib.import_module("tino_storm.search")
+
+    assert module.search_sync is not None
+    assert "tino_storm.core.rm" not in sys.modules


### PR DESCRIPTION
### Motivation
- Avoid importing heavy/optional Bing search integrations at module import time so importing `tino_storm.search`/providers does not require the llm extras.
- Provide actionable errors and graceful runtime fallback when Bing-related optional dependencies are missing.

### Description
- Removed the top-level `from ..core.rm import BingSearch` and added a lazy loader `_load_bing_search_class()` that imports `BingSearch` only when needed.
- The lazy loader calls `require_extra(...)` for `backoff`, `dspy` (via `package="dspy_ai"`) and `dsp`, and raising `MissingExtraError` if any optional dependency is absent.
- `DefaultProvider._bing_search` now constructs `BingSearch` inside a `try` block and handles `MissingExtraError` by logging, emitting a `ResearchAdded` event, and returning an empty list as a graceful fallback.
- Updated/added tests in `tests/test_bing_search_import.py` and `tests/test_optional_dependencies.py` to assert that `tino_storm.search` and `tino_storm.providers.base` can be imported without the Bing/LLM extras and that `_bing_search` falls back when extras are missing.

### Testing
- Ran linter checks: `python -m ruff check src/tino_storm/providers/base.py tests/test_optional_dependencies.py tests/test_bing_search_import.py` and the check succeeded.
- Ran unit tests: `python -m pytest tests/test_optional_dependencies.py tests/test_bing_search_import.py -q` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3950cab1008326a3046ff57e50d2ca)